### PR TITLE
Fix form fill for single select fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix form fill for single select fields.
+  [jone]
 
 
 1.5.0 (2014-01-03)

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -111,6 +111,11 @@ class Form(NodeWrapper):
                 field.node.text = value
                 del values[fieldname]
 
+            # lxml.html.formfill cannot fill select fields properly.
+            if field and field.tag == 'select' and not field.get('multiple'):
+                field.node.value = value
+                del values[fieldname]
+
             # lxml.html.formfill cannot handle file uploads.
             # We use mechanize to do this.
             if field and field.tag == 'input' and field.type == 'file':

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -170,3 +170,39 @@ class TestSelectField(TestCase):
         self.assertEquals('foo', browser.find('Select Field').value)
         browser.find('Select Field').value = 'bar'
         self.assertEquals('bar', browser.find('Select Field').value)
+
+    @browsing
+    def test_fill_value(self, browser):
+        browser.open_html('\n'.join((
+                    '<html><body>',
+                    ' <form id="form">',
+                    '  <label for="field">Select Field</label>',
+                    '  <select id="field" name="field">',
+                    '    <option value="foo" selected>Foo</option>',
+                    '    <option value="bar">Bar</option>',
+                    '    <option value="baz">Baz</option>',
+                    '  </select>',
+                    ' </form>'
+                    '</body></html>')))
+
+        self.assertEquals('foo', browser.find('Select Field').value)
+        browser.fill({'Select Field': 'bar'})
+        self.assertEquals('bar', browser.find('Select Field').value)
+
+    @browsing
+    def test_fill_multi_select(self, browser):
+        browser.open_html('\n'.join((
+                    '<html><body>',
+                    ' <form id="form">',
+                    '  <label for="field">Select Field</label>',
+                    '  <select id="field" name="field" multiple="multiple">',
+                    '    <option value="foo" selected>Foo</option>',
+                    '    <option value="bar">Bar</option>',
+                    '    <option value="baz">Baz</option>',
+                    '  </select>',
+                    ' </form>'
+                    '</body></html>')))
+
+        self.assertEquals(['foo'], list(browser.find('Select Field').value))
+        browser.fill({'Select Field': ['bar', 'baz']})
+        self.assertEquals(['bar', 'baz'], list(browser.find('Select Field').value))


### PR DESCRIPTION
Somewhere in lxml / libxml there is an error when filling single valued select fields
the way lxml.html.formfill does it.

This workaround fixes form filling in ftw.testbrowser.

Fixes #3 
/cc @elioschmutz 
