### PR TITLE
ContentTreeWidget: support filling objects as values.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ContentTreeWidget: support filling objects as values.
+  [jone]
 
 
 1.6.1 (2014-01-31)

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -24,6 +24,11 @@ class BrowserLayer(PloneSandboxLayer):
                        plone.formwidget.autocomplete,
                        context=configurationContext)
 
+        import plone.formwidget.contenttree
+        xmlconfig.file('configure.zcml',
+                       plone.formwidget.contenttree,
+                       context=configurationContext)
+
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.formwidget.autocomplete:default')
 

--- a/ftw/testbrowser/tests/test_widgets_contenttree.py
+++ b/ftw/testbrowser/tests/test_widgets_contenttree.py
@@ -1,0 +1,40 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+
+
+class TestContentTreeWidget(TestCase):
+
+    layer = BROWSER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ['Manager'])
+        login(portal, TEST_USER_NAME)
+
+    @browsing
+    def test_selecting_object(self, browser):
+        foo = create(Builder('document').titled('Foo'))
+        bar = create(Builder('document').titled('Bar'))
+
+        browser.login().visit(view='test-z3cform-shopping')
+        browser.fill({'Documents': (foo, bar)})
+        browser.find('Submit').click()
+        self.assertEquals({u'documents': [u'/foo',
+                                          u'/bar']},
+                          browser.json)
+
+    @browsing
+    def test_querying_objects(self, browser):
+        create(Builder('document').titled('The Document'))
+
+        browser.login().visit(view='test-z3cform-shopping')
+
+        self.assertEquals([['/plone/the-document', 'The Document']],
+                          browser.find('Documents').query('doc'))

--- a/ftw/testbrowser/tests/views/z3cform.py
+++ b/ftw/testbrowser/tests/views/z3cform.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
+from plone.formwidget.contenttree import MultiContentTreeFieldWidget
+from plone.formwidget.contenttree import PathSourceBinder
+from plone.formwidget.contenttree import ObjPathSourceBinder
 from plone.z3cform.layout import FormWrapper
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.browser.radio import RadioFieldWidget
@@ -61,6 +64,11 @@ class IShoppingFormSchema(Interface):
         title=u'Delivery date',
         required=False)
 
+    documents = schema.List(
+        title=u'Documents',
+        value_type=schema.Choice(
+            source=PathSourceBinder(portal_type='Document')))
+
 
 class ShoppingForm(Form):
     label = u'Shopping'
@@ -75,6 +83,7 @@ class ShoppingForm(Form):
         self.fields['fruits'].widgetFactory = CheckBoxFieldWidget
         self.fields['bag'].widgetFactory = RadioFieldWidget
         self.fields['payment'].widgetFactory = AutocompleteMultiFieldWidget
+        self.fields['documents'].widgetFactory = MultiContentTreeFieldWidget
         return super(ShoppingForm, self).update()
 
     @buttonAndHandler(u'Submit')

--- a/ftw/testbrowser/widgets/autocomplete.py
+++ b/ftw/testbrowser/widgets/autocomplete.py
@@ -17,12 +17,16 @@ class AutocompleteWidget(PloneWidget):
 
     def fill(self, values):
         """Fill the autocomplete value with a key from the vocabulary.
+        For content tree widgets, the value may be a Plone object which
+        will be replaced with the object path.
 
         :param values: value to fill the autocomplete field with.
-        :type values: string
+        :type values: string or object
         """
         if not isinstance(values, (list, set, tuple)):
             values = [values]
+
+        values = self._resolve_objects_to_path(values)
 
         container = self.css('div.autocompleteInputWidget').first
         fieldname = '%s:list' % self.fieldname
@@ -66,3 +70,12 @@ class AutocompleteWidget(PloneWidget):
             query_browser.open(url, data={'q': query_string})
             return map(lambda line: line.split('|'),
                        query_browser.contents.split('\n'))
+
+    def _resolve_objects_to_path(self, values):
+        new_values = []
+        for value in values:
+            if hasattr(value, 'getPhysicalPath'):
+                new_values.append('/'.join(value.getPhysicalPath()))
+            else:
+                new_values.append(value)
+        return new_values


### PR DESCRIPTION
Make it possible to pass Plone objects into the form fill method
as values for content tree widgets.

Example:

``` python
    browser.fill({'References': [obj]})
```
