### PR TITLE
Form: Support checking checkboxes without a value.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Form: Support checking checkboxes without a value.
+  Checkboxes without a value attribute are invalid but common.
+  The default browser behavior is to fallback to the value "on".
+  [jone]
 
 
 1.7.0 (2014-02-03)

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -131,7 +131,7 @@ class Form(NodeWrapper):
             # independent of the actual field value.
             if field and field.tag == 'input' and field.type == 'checkbox' \
                     and value is True:
-                values[fieldname] = field.node.attrib['value']
+                values[fieldname] = field.node.attrib.get('value', 'on')
 
         lxml.html.formfill._fill_form(self.node, values)
 

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -18,7 +18,7 @@ import lxml.html
 
 class TestBrowserForms(TestCase):
 
-    layer = PLONE_FUNCTIONAL_TESTING
+    layer = BROWSER_FUNCTIONAL_TESTING
 
     @browsing
     def test_find_form_by_field_label(self, browser):
@@ -106,6 +106,16 @@ class TestBrowserForms(TestCase):
         self.assertEquals(False, browser.find('Exclude from navigation').checked)
         browser.fill({'Exclude from navigation': True})
         self.assertEquals(True, browser.find('Exclude from navigation').checked)
+
+    @browsing
+    def test_filling_checkbox_without_a_value(self, browser):
+        # Having checkboxes without a value attribtue is invalid but common.
+        # The common default is to use "on" as the value.
+        browser.visit(view='test-form')
+        browser.fill({'checkbox-without-value': True}).submit()
+        self.assertDictContainsSubset(
+            {u'checkbox-without-value': u'on'},
+            browser.json)
 
     @browsing
     def test_at_fill_tinymce_field(self, browser):

--- a/ftw/testbrowser/tests/views/test-form.pt
+++ b/ftw/testbrowser/tests/views/test-form.pt
@@ -10,6 +10,7 @@
             <form id="test-form" action="test-form-result">
                 <label for="textfield">Text field</label>
                 <input name="textfield" id="textfield" value="" />
+                <input type="checkbox" name="checkbox-without-value" />
 
                 <input type="submit" value="Submit" name="submit-button" />
                 <input type="submit" value="Cancel" name="cancel-button" />


### PR DESCRIPTION
Checkboxes without a value attribute are invalid but common.
The default browser behavior is to fallback to the value "on".

/ @maethu 
