### PR TITLE
Fix problems when filling forms which have checked checkedbox.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.13.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix problems when filling forms which have checked checkedbox.
+  [phgross]
 
 
 1.13.1 (2014-07-15)

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -3,6 +3,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING
+from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
 from plone.app.testing import SITE_OWNER_NAME
 from unittest2 import TestCase
 
@@ -35,3 +36,32 @@ class TestDexterityForms(TestCase):
         browser.fill({'Title': u'F\xf6lder'}).save()
         statusmessages.assert_no_error_messages()
         self.assertEquals(u'F\xf6lder', plone.first_heading())
+
+    @browsing
+    def test_changing_checkbox_values(self, browser):
+        browser.login(SITE_OWNER_NAME).open()
+        factoriesmenu.add('Page')
+        browser.fill({'Title': u'Page',
+                      'Exclude from navigation': True}).save()
+        statusmessages.assert_no_error_messages()
+        self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
+
+        browser.find('Edit').click()
+        browser.fill({'Title': 'New Title',
+                             'Exclude from navigation': False}).save()
+        statusmessages.assert_no_error_messages()
+        self.assertFalse(IExcludeFromNavigation(browser.context).exclude_from_nav)
+
+    @browsing
+    def test_checkbox_values_are_preserved(self, browser):
+        browser.login(SITE_OWNER_NAME).open()
+        factoriesmenu.add('Page')
+        browser.fill({'Title': u'Page',
+                      'Exclude from navigation': True}).save()
+        statusmessages.assert_no_error_messages()
+        self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
+
+        browser.find('Edit').click()
+        browser.fill({'Title': 'New Title'}).save()
+        statusmessages.assert_no_error_messages()
+        self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)


### PR DESCRIPTION
Given an form with a already checked checkbox (e.g. checked=checked), when this form is filled without changing this checkbox, the lxml formfill unchecks the checkbox.

Therefore we need to re-add all already checked checkboxes to the values to fill unless the value is meant to be changed.
