### PR TITLE
Filling selects: verbose error message when option not found.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.13.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Filling selects: verbose error message when option not found.
+  The available options are now included in the message.
+  [jone]
 
 
 1.13.3 (2014-09-02)

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -132,7 +132,7 @@ class Form(NodeWrapper):
 
             # lxml.html.formfill cannot fill select fields properly.
             if field and field.tag == 'select' and not field.get('multiple'):
-                field.node.value = value
+                field.value = value
                 del values[fieldname]
 
             # lxml.html.formfill cannot handle file uploads.
@@ -525,3 +525,20 @@ class SelectField(NodeWrapper):
         :rtype: list of strings
         """
         return [value for (value, label) in self.options]
+
+    def __setattr__(self, name, value):
+        if name == 'value':
+            return self.set_value(value)
+        return super(SelectField, self).__setattr__(name, value)
+
+    def set_value(self, value):
+        try:
+            self.node.value = value
+        except ValueError:
+            options = ', '.join(['"{1}" ({0})'.format(*option)
+                                 for option in self.options])
+
+            raise ValueError(
+                'No option {0} for select "{1}".'
+                ' Available options: {2}.'.format(
+                    repr(value), self.name, options))

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -281,6 +281,27 @@ class TestSelectField(TestCase):
         self.assertEquals('bar', browser.find('Select Field').value)
 
     @browsing
+    def test_verbose_message_when_no_option_matches(self, browser):
+        browser.open_html('\n'.join((
+                    '<html><body>',
+                    ' <form id="form">',
+                    '  <label for="field">Select Field</label>',
+                    '  <select id="field" name="field">',
+                    '    <option value="foo">Foo</option>',
+                    '    <option value="bar">Bar</option>',
+                    '  </select>',
+                    ' </form>'
+                    '</body></html>')))
+
+        with self.assertRaises(ValueError) as cm:
+            browser.fill({'Select Field': 'baz'})
+
+        self.assertEquals(
+            "No option u'baz' for select \"field\". "
+            'Available options: "Foo" (foo), "Bar" (bar).',
+                          str(cm.exception))
+
+    @browsing
     def test_fill_multi_select(self, browser):
         browser.open_html('\n'.join((
                     '<html><body>',


### PR DESCRIPTION
The available options are now included in the message.
