### PR TITLE
AutocompleteWidget: Drop query string from base URL when building query URL.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- AutocompleteWidget: Drop query string from base URL when building query URL.
+  [lgraf]
 
 
 1.14.4 (2014-10-03)

--- a/ftw/testbrowser/tests/test_widgets_autocomplete.py
+++ b/ftw/testbrowser/tests/test_widgets_autocomplete.py
@@ -2,6 +2,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
 from plone.app.testing import SITE_OWNER_NAME
 from unittest2 import TestCase
+from urlparse import urljoin
 
 
 class TestBrowserZ3CForms(TestCase):
@@ -18,6 +19,16 @@ class TestBrowserZ3CForms(TestCase):
     @browsing
     def test_autocomplete_query(self, browser):
         browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
+
+        self.assertEquals([['cash', 'Cash'],
+                           ['mastercard', 'MasterCard']],
+                          browser.find('Payment').query('ca'))
+
+    @browsing
+    def test_autocomplete_query_with_querystring_in_base_url(self, browser):
+        view_url = browser._normalize_url(None, view='test-z3cform-shopping')
+        url = urljoin(view_url, '?key=value')
+        browser.login(SITE_OWNER_NAME).visit(url)
 
         self.assertEquals([['cash', 'Cash'],
                            ['mastercard', 'MasterCard']],

--- a/ftw/testbrowser/widgets/autocomplete.py
+++ b/ftw/testbrowser/widgets/autocomplete.py
@@ -1,6 +1,8 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 from lxml import etree
+from urlparse import urlsplit
+from urlparse import urlunsplit
 
 
 @widget
@@ -56,14 +58,21 @@ class AutocompleteWidget(PloneWidget):
 
         """
 
-        url = '/'.join((self.browser.url,
-                        '++widget++%s' % self.fieldname,
-                        '@@autocomplete-search'))
+        url = self._get_query_url()
 
         with self.browser.clone() as query_browser:
             query_browser.open(url, data={'q': query_string})
             return map(lambda line: line.split('|'),
                        query_browser.contents.split('\n'))
+
+    def _get_query_url(self):
+        scheme, netloc, path, query, fragment = urlsplit(self.browser.url)
+        # Drop query and fragment from the base URL
+        base_url = urlunsplit((scheme, netloc, path, '', ''))
+        url = '/'.join((base_url,
+                        '++widget++%s' % self.fieldname,
+                        '@@autocomplete-search'))
+        return url
 
     def _resolve_objects_to_path(self, values):
         new_values = []


### PR DESCRIPTION
If the `browser`'s current URL contains a query string component, the URL built by [`AutocompleteWidget.query()`](https://github.com/4teamwork/ftw.testbrowser/blob/31a2799124e4c14fba22e2e5ad3202329992c547/ftw/testbrowser/widgets/autocomplete.py#L59-61) currently will look like this:
`http://nohost/plone/@@view?key=value/++widget++form.widgets.field/@@autocomplete-search`

This change fixes this so that when building the query URL, the query string and fragment components are dropped from the base URL.

@jone

