### PR TITLE
Added tests for z3c date fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added tests for z3c date fields.
+  [phgross]
 
 
 1.14.5 (2015-01-30)

--- a/ftw/testbrowser/tests/test_widgets_date.py
+++ b/ftw/testbrowser/tests/test_widgets_date.py
@@ -1,0 +1,18 @@
+from datetime import date
+from ftw.testbrowser import browsing
+from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from plone.app.testing import SITE_OWNER_NAME
+from unittest2 import TestCase
+
+
+class TestDateWidget(TestCase):
+
+    layer = BROWSER_FUNCTIONAL_TESTING
+
+    @browsing
+    def test_z3cform_datefield_formfill(self, browser):
+        browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
+        browser.fill({'Day of payment': date(2015, 10, 22)})
+        browser.find('Submit').click()
+        self.assertEquals({u'day_of_payment': u'2015-10-22'},
+                          browser.json)

--- a/ftw/testbrowser/tests/views/z3cform.py
+++ b/ftw/testbrowser/tests/views/z3cform.py
@@ -1,3 +1,4 @@
+from datetime import date
 from datetime import datetime
 from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
 from plone.formwidget.contenttree import MultiContentTreeFieldWidget
@@ -10,8 +11,8 @@ from z3c.form.field import Fields
 from z3c.form.form import Form
 from z3c.formwidget.query.interfaces import IQuerySource
 from zope import schema
-from zope.interface import Interface
 from zope.interface import implements
+from zope.interface import Interface
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
@@ -63,6 +64,10 @@ class IShoppingFormSchema(Interface):
         title=u'Delivery date',
         required=False)
 
+    day_of_payment = schema.Date(
+        title=u'Day of payment',
+        required=False)
+
     documents = schema.List(
         title=u'Documents',
         value_type=schema.Choice(
@@ -96,7 +101,7 @@ class ShoppingForm(Form):
             if not value:
                 continue
 
-            if isinstance(value, datetime):
+            if isinstance(value, (datetime, date)):
                 value = value.isoformat()
 
             self.result_data[key] = value


### PR DESCRIPTION
The z3c date fields are already handled by the `DatetimeWidget`, no adjustments needed.

@jone 