### PR TITLE
Add browser properties ``contenttype``, ``mimetype`` and ``encoding``.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.14.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add browser properties ``contenttype``, ``mimetype`` and ``encoding``.
+  [jone]
 
 
 1.14.6 (2015-04-17)

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -21,6 +21,7 @@ import lxml
 import lxml.html
 import os
 import pkg_resources
+import re
 import requests
 import tempfile
 import urllib
@@ -377,6 +378,32 @@ class Browser(object):
         else:
             # Page was opened with open_html - we have no response headers.
             return {}
+
+    @property
+    def contenttype(self):
+        """The contenttype of the response, e.g. ``text/html; charset=utf-8``.
+
+        .. seealso:: :py:func:`mimetype`, :py:func:`encoding`
+        """
+        return self.headers.get('Content-Type', '')
+
+    @property
+    def mimetype(self):
+        """The mimetype of the respone, e.g. ``text/html``.
+
+        .. seealso:: :py:func:`contenttype`
+        """
+        return self.contenttype.split(';', 1)[0]
+
+    @property
+    def encoding(self):
+        """The encoding of the respone, e.g. ``utf-8``.
+
+        .. seealso:: :py:func:`contenttype`
+        """
+        match = re.match(r'[^;]*; ?charset="?([^"]*)"?', self.contenttype)
+        if match:
+            return match.group(1)
 
     def append_request_header(self, name, value):
         """Add a new permanent request header which is sent with every request

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -286,6 +286,29 @@ class TestMechanizeBrowserRequests(TestCase):
             {u'values': [u'Foo', u'Bar']},
             browser.json)
 
+    @browsing
+    def test_response_contenttype(self, browser):
+        browser.open()
+        self.assertEquals('text/html; charset=utf-8', browser.contenttype)
+
+        browser.open(self.json_view_url, data={'foo': 'bar'})
+        self.assertEquals('application/json', browser.contenttype)
+
+    @browsing
+    def test_response_mimetype(self, browser):
+        browser.open()
+        self.assertEquals('text/html', browser.mimetype)
+
+        browser.open(self.json_view_url, data={'foo': 'bar'})
+        self.assertEquals('application/json', browser.mimetype)
+
+    @browsing
+    def test_response_encoding(self, browser):
+        browser.open()
+        self.assertEquals('utf-8', browser.encoding)
+
+        browser.open(self.json_view_url, data={'foo': 'bar'})
+        self.assertEquals(None, browser.encoding)
 
 
 class TestRequestslibBrowserRequests(TestCase):


### PR DESCRIPTION
The new properties on the browser instance contain information about the response
content type.

Examples:

- ``browser.contenttype``: ``text/html; charset=utf8``
- ``browser.mimetype``: ``text/html``
- ``browser.encoding``: ``utf8;``