### PR TITLE
Parse XML responses with XML parser instead of HTML parser.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.14.7 (unreleased)
 -------------------
 
+- Parse XML responses with XML parser instead of HTML parser.
+  New methods for parsing the response: ``parse_as_html``,
+  ``parse_as_xml`` and ``parse``.
+  [jone]
+
 - Add browser properties ``contenttype``, ``mimetype`` and ``encoding``.
   [jone]
 

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -402,6 +402,33 @@ See the API documentation for the page objects included in `ftw.testbrowser`:
 .. seealso:: :py:mod:`ftw.testbrowser.pages`
 
 
+XML Support
+===========
+
+When the response mimetype is ``text/xml`` or ``application/xml``, the response body is
+parsed as XML instead of HTML.
+
+This can lead to problems when having XML-Documents with a default namespace,
+because lxml only supports XPath 1, which does not support default namespaces.
+
+You can either solve the problem yourself by parsing the ``browser.contents`` or you
+may switch back to HTML parsing.
+HTML parsing will modify your document though, it will insert a ``html`` node for example.
+
+Re-parsing with another parser:
+
+.. code:: py
+
+    browser.webdav(view='something.xml')  # XML document
+    browser.parse_as_html()               # HTML document
+    browser.parse_as_xml()                # XML document
+
+
+.. seealso:: :py:mod:`ftw.testbrowser.core.Browser.parse_as_html`
+.. seealso:: :py:mod:`ftw.testbrowser.core.Browser.parse_as_xml`
+.. seealso:: :py:mod:`ftw.testbrowser.core.Browser.parse`
+
+
 WebDAV requests
 ===============
 

--- a/ftw/testbrowser/nodes.py
+++ b/ftw/testbrowser/nodes.py
@@ -338,7 +338,7 @@ class NodeWrapper(object):
             return result
 
     def __setattr__(self, name, value):
-        if name != 'node':
+        if name not in ('node', '_browser'):
             setattr(self.node, name, value)
         else:
             super(NodeWrapper, self).__setattr__(name, value)

--- a/ftw/testbrowser/nodes.py
+++ b/ftw/testbrowser/nodes.py
@@ -414,7 +414,8 @@ class NodeWrapper(object):
         :rtype: :py:class:`ftw.testbrowser.nodes.Nodes`
         """
         query_info = query_info or (self, 'xpath', xpath_selector)
-        return wrap_nodes(self.node.xpath(xpath_selector),
+        nsmap = self.node.getroottree().getroot().nsmap
+        return wrap_nodes(self.node.xpath(xpath_selector, namespaces=nsmap),
                           self.browser,
                           query_info=query_info)
 

--- a/ftw/testbrowser/nodes.py
+++ b/ftw/testbrowser/nodes.py
@@ -322,6 +322,8 @@ class NodeWrapper(object):
     """
 
     def __init__(self, node, browser):
+        if isinstance(node, NodeWrapper):
+            node = node.node
         self.node = node
         self._browser = browser
 

--- a/ftw/testbrowser/tests/assets/cities-iso-8859-1.xml
+++ b/ftw/testbrowser/tests/assets/cities-iso-8859-1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<cities>
+    <title>Städteverzeichnis</title>
+    <city>Bern</city>
+    <city>Zürich</city>
+    <city>Basel</city>
+</cities>

--- a/ftw/testbrowser/tests/assets/cities-utf8.xml
+++ b/ftw/testbrowser/tests/assets/cities-utf8.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cities>
+    <title>Städteverzeichnis</title>
+    <city>Bern</city>
+    <city>Zürich</city>
+    <city>Basel</city>
+</cities>

--- a/ftw/testbrowser/tests/test_webdav_requests.py
+++ b/ftw/testbrowser/tests/test_webdav_requests.py
@@ -32,7 +32,7 @@ class TestWebdavRequests(TestCase):
                 ))
         browser.login().webdav('PROPFIND', data=data)
         self.assertEquals('Plone site',
-                          browser.xpath('//displayname').first.normalized_text())
+                          browser.xpath('//d:displayname').first.text)
 
 
 class TestNoZserverWebdavRequests(TestCase):

--- a/ftw/testbrowser/tests/test_xml_document.py
+++ b/ftw/testbrowser/tests/test_xml_document.py
@@ -1,0 +1,36 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from unittest2 import TestCase
+
+
+class TestXMLDocument(TestCase):
+    layer = BROWSER_FUNCTIONAL_TESTING
+
+    @browsing
+    def test_utf8_document_with_umlaut(self, browser):
+        browser.open(view='test-asset', data={'filename': 'cities-utf8.xml'})
+        self.assertEquals('text/xml; charset=utf-8',
+                          browser.contenttype)
+        self.assertEquals('cities',
+                          browser.document.getroot().tag)
+        self.assertEquals([u'Bern', u'Z\xfcrich', u'Basel'],
+                          browser.css('city').text)
+
+    @browsing
+    def test_ISO_8859_1_document_with_umlaut(self, browser):
+        browser.open(view='test-asset', data={'filename': 'cities-iso-8859-1.xml'})
+        self.assertEquals('text/xml; charset=ISO-8859-1',
+                          browser.contenttype)
+        self.assertEquals('cities',
+                          browser.document.getroot().tag)
+        self.assertEquals([u'Bern', u'Z\xfcrich', u'Basel'],
+                          browser.css('city').text)
+
+    @browsing
+    def test_reparse_with_html_parse(self, browser):
+        browser.open(view='test-asset', data={'filename': 'cities-iso-8859-1.xml'})
+        self.assertEquals('cities', browser.document.getroot().tag)
+        browser.parse_as_html()
+        self.assertEquals('html', browser.document.getroot().tag)
+        browser.parse_as_xml()
+        self.assertEquals('cities', browser.document.getroot().tag)

--- a/ftw/testbrowser/tests/views/configure.zcml
+++ b/ftw/testbrowser/tests/views/configure.zcml
@@ -65,6 +65,13 @@
         permission="cmf.ModifyPortalContent"
         />
 
+    <browser:page
+        name="test-asset"
+        class=".views.TestAsset"
+        for="*"
+        permission="zope.Public"
+        />
+
     <utility
         factory=".z3cform.PaymentVocabulary"
         provides="zope.schema.interfaces.IVocabularyFactory"


### PR DESCRIPTION
The lxml.html.parse method wraps the document into a <html>-node when it is
a non-HTML XML document.

We'd like the testbrowser to helpful for testing XML responses as well,
therefore regular XML documents are now parsed with the xml.etree.parse function.

The default parser is still the HTML-parser so that we do not break existing functionality.

:construction: namespaces are not yet working properly..