### PR TITLE
Autocomplete widget: extract URL from javascript.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Autocomplete widget: extract URL from javascript.
+  [jone]
 
 
 1.16.0 (2015-07-08)

--- a/ftw/testbrowser/widgets/autocomplete.py
+++ b/ftw/testbrowser/widgets/autocomplete.py
@@ -1,8 +1,7 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 from lxml import etree
-from urlparse import urlsplit
-from urlparse import urlunsplit
+import re
 
 
 @widget
@@ -66,12 +65,8 @@ class AutocompleteWidget(PloneWidget):
                        query_browser.contents.split('\n'))
 
     def _get_query_url(self):
-        scheme, netloc, path, query, fragment = urlsplit(self.browser.url)
-        # Drop query and fragment from the base URL
-        base_url = urlunsplit((scheme, netloc, path, '', ''))
-        url = '/'.join((base_url,
-                        '++widget++%s' % self.fieldname,
-                        '@@autocomplete-search'))
+        javascript = self.css('script').first.text
+        url = re.search(r"\)\.autocomplete\([^']*'([^']*)'", javascript).group(1)
         return url
 
     def _resolve_objects_to_path(self, values):


### PR DESCRIPTION
The problem is that the browser-url may be wrong after a post (such as when creating a portlet).
For actually doing the same as in the real-world, we need to extract the URL from the generated javascript.

/ @mbaechtold 

:construction: 
@phgross  @lukasgraf this might not work with the jQuery UI version of the autocomplete widget because of different javascript code. Can anybody verify if it works and maybe post the the JS so that we can make it work for both versions?