### PR TITLE
Fix GET form submission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.18.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix GET form submission to actually submit it with GET.
+  [jone]
 
 
 1.18.0 (2015-07-22)

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -12,6 +12,7 @@ from StringIO import StringIO
 import lxml.html.formfill
 import mimetypes
 import shutil
+import urllib
 import urlparse
 
 
@@ -324,6 +325,13 @@ class Form(NodeWrapper):
 
     def _submit_form(self, method, URL, values):
         URL = self.action_url
+
+        if method.lower() == 'get':
+            if '?' in URL:
+                URL += '&' + urllib.urlencode(values)
+            else:
+                URL += '?' + urllib.urlencode(values)
+            return self.browser.open(URL, referer=True)
 
         if self.browser.request_library == LIB_MECHANIZE:
             return self._make_mechanize_multipart_request(URL, values)

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -239,6 +239,18 @@ class TestSubmittingForms(TestCase):
         self.assertEquals({'textfield': '',
                            'cancel-button': 'Cancel'}, browser.json)
 
+    @browsing
+    def test_submitting_GET_form(self, browser):
+        browser.visit(view='test-form')
+        browser.fill({'atext': 'foo'}).submit()
+        self.assertEquals({'atext': 'foo',
+                           'formmethod': 'GET',
+                           'submit-button': 'Submit'}, browser.json)
+        self.assertEquals(
+            'http://nohost/plone/test-form-result?formmethod=GET'
+            '&atext=foo&submit-button=Submit',
+            browser.url)
+
 
 class TestSelectField(TestCase):
 

--- a/ftw/testbrowser/tests/views/test-form.pt
+++ b/ftw/testbrowser/tests/views/test-form.pt
@@ -16,6 +16,13 @@
                 <input type="submit" value="Cancel" name="cancel-button" />
             </form>
 
+            <form id="test-get-form" action="test-form-result?formmethod=GET"
+                  method="GET">
+                <label for="atext">Text field</label>
+                <input name="atext" id="atext" value="" />
+                <input type="submit" value="Submit" name="submit-button" />
+            </form>
+
         </div>
 
     </body>


### PR DESCRIPTION
Forms with method "GET" were also submitted using "POST", as a multipart request.
This changes "GET"-forms to actually be submitted as "GET", which is by encoding the form values and appending them as querystring to the action URL.