### PR TITLE
Fix encoding error in assertion message.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.18.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix encoding error in assertion message when selecting a missing select
+  option.
+  [mbaechtold]
 
 
 1.18.1 (2015-07-23)

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -550,10 +550,10 @@ class SelectField(NodeWrapper):
             try:
                 self.node.value = dict(map(reversed, self.options))[value]
             except (KeyError, ValueError):
-                options = ', '.join(['"{1}" ({0})'.format(*option)
-                                     for option in self.options])
+                options = u', '.join([u'"{1}" ({0})'.format(*option)
+                                      for option in self.options])
 
                 raise ValueError(
-                    'No option {0} for select "{1}".'
-                    ' Available options: {2}.'.format(
+                    u'No option {0} for select "{1}". '
+                    u'Available options: {2}.'.format(
                         repr(value), self.name, options))

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -294,24 +294,26 @@ class TestSelectField(TestCase):
 
     @browsing
     def test_verbose_message_when_no_option_matches(self, browser):
-        browser.open_html('\n'.join((
-                    '<html><body>',
-                    ' <form id="form">',
-                    '  <label for="field">Select Field</label>',
-                    '  <select id="field" name="field">',
-                    '    <option value="foo">Foo</option>',
-                    '    <option value="bar">Bar</option>',
-                    '  </select>',
-                    ' </form>'
-                    '</body></html>')))
+        browser.open_html(u'\n'.join((
+            u'<html><body>',
+            u' <form id="form">',
+            u'  <label for="field">Select Field</label>',
+            u'  <select id="field" name="field">',
+            u'    <option value="">Please choose\u2026</option>',
+            u'    <option value="foo">Foo</option>',
+            u'    <option value="bar">Bar</option>',
+            u'  </select>',
+            u' </form>'
+            u'</body></html>')))
 
         with self.assertRaises(ValueError) as cm:
             browser.fill({'Select Field': 'baz'})
 
         self.assertEquals(
-            "No option u'baz' for select \"field\". "
-            'Available options: "Foo" (foo), "Bar" (bar).',
-                          str(cm.exception))
+            u'No option u\'baz\' for select "field". '
+            u'Available options: "Please choose\u2026" (), '
+            u'"Foo" (foo), "Bar" (bar).',
+            cm.exception.message)
 
     @browsing
     def test_fill_multi_select(self, browser):


### PR DESCRIPTION
The encoding error occurs if one tries to select a missing select option and one of the available options contains non-ASCII characters.

Fixes #30