### PR TITLE
Implement browser.click_on(tex) short cut.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.18.2 (unreleased)
 -------------------
 
+- Implement browser.click_on(tex) short cut for clicking links.
+  [jone]
+
 - Fix encoding error in assertion message when selecting a missing select
   option.
   [mbaechtold]

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -3,6 +3,7 @@ from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.exceptions import ContextNotFound
 from ftw.testbrowser.exceptions import FormFieldNotFound
+from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.exceptions import ZServerRequired
 from ftw.testbrowser.interfaces import IBrowser
 from ftw.testbrowser.nodes import wrap_nodes
@@ -756,6 +757,24 @@ class Browser(object):
         return reduce(list.__add__,
                       map(attrgetter('field_labels'),
                           self.forms.values()))
+
+    def click_on(self, text, within=None):
+        """Find a link by its text and click on it.
+
+        :param text: The text to be looked for.
+        :type text: string
+        :param within: A node object for limiting the scope of the search.
+        :type within: :py:class:`ftw.testbrowser.nodes.NodeWrapper`.
+        :returns: The browser object.
+        :raises: :py:exc:`ftw.testbrowser.exceptions.NoElementFound`
+        .. seealso:: :py:func:`find`
+        """
+        node = self.find(text)
+        if not node:
+            raise NoElementFound(query_info=(self, 'click_on', text))
+
+        node.click()
+        return self
 
     @property
     def context(self):

--- a/ftw/testbrowser/tests/test_nodes.py
+++ b/ftw/testbrowser/tests/test_nodes.py
@@ -714,6 +714,22 @@ class TestLinkNode(TestCase):
         browser.open().find('Site Map').click()
         self.assertEquals('sitemap', plone.view())
 
+    @browsing
+    def test_click_on_shortcut(self, browser):
+        browser.open().click_on('Site Map')
+        self.assertEquals('sitemap', plone.view())
+
+    @browsing
+    def test_click_on_raises_helpful_error_when_link_missing(self, browser):
+        browser.open()
+        with self.assertRaises(NoElementFound) as cm:
+            browser.click_on('Missing')
+
+        self.assertEquals(
+            'Empty result set: <ftw.browser.core.Browser instance>'
+            '.click_on("Missing") did not match any nodes.',
+            str(cm.exception))
+
 
 class TestDefinitionListNode(TestCase):
 


### PR DESCRIPTION
This is shortcut for browser.find(text).click.