### PR TITLE
Preserve radio-button input when filling forms with radio buttons.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.19.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Preserve radio-button input when filling forms with radio buttons.
+  [deiferni]
 
 
 1.19.0 (2015-07-31)

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -150,8 +150,7 @@ class Form(NodeWrapper):
                     and value is True:
                 values[fieldname] = field.node.attrib.get('value', 'on')
 
-
-        values = self._merge_already_checked_checkboxes(values)
+        values = self._merge_already_checked_inputs(values)
 
         lxml.html.formfill._fill_form(self.node, values)
 
@@ -160,11 +159,11 @@ class Form(NodeWrapper):
 
         return self
 
-    def _merge_already_checked_checkboxes(self, values):
-        # Given a form with a already checked checkbox (e.g. checked=checked),
-        # when this form is filled without changing this checkbox,
-        # the lxml formfill unchecks the checkbox.
-        # Therefore we need to re-add all already checked checkboxes to
+    def _merge_already_checked_inputs(self, values):
+        # Given a form with an already checked input element (e.g.
+        # checked=checked), when this form is filled without changing the input
+        # element the lxml formfill unchecks the element.
+        # Therefore we need to re-add all already checked inputs to
         # the values to fill unless the value is meant to be changed.
         to_merge = defaultdict(list)
 
@@ -172,7 +171,8 @@ class Form(NodeWrapper):
             if input.name in values:
                 continue
 
-            if input.attrib.get('type', '').lower() != 'checkbox':
+            input_type = input.attrib.get('type', '').lower()
+            if input_type not in ['checkbox', 'radio']:
                 continue
 
             if input.attrib.get('checked', None) is not None:

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -1,11 +1,12 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PLONE_ZSERVER
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from zope.configuration import xmlconfig
 
 
@@ -41,3 +42,25 @@ BROWSER_ZSERVER_FUNCTIONAL_TESTING = FunctionalTesting(
            set_builder_session_factory(functional_session_factory),
            PLONE_ZSERVER),
     name="ftw.testbrowser:functional:zserver")
+
+
+class DxTypesLayer(PloneSandboxLayer):
+
+    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        import ftw.testbrowser.tests
+        xmlconfig.file('profiles/dxtype.zcml',
+                       ftw.testbrowser.tests,
+                       context=configurationContext)
+
+    def setUpPloneSite(self, portal):
+        applyProfile(
+            portal, 'ftw.testbrowser.tests:dxtype')
+
+
+DX_TYPES_FIXTURE = DxTypesLayer()
+DX_TYPES_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(DX_TYPES_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="ftw.testbrowser:dx-functional")

--- a/ftw/testbrowser/tests/interfaces.py
+++ b/ftw/testbrowser/tests/interfaces.py
@@ -1,0 +1,28 @@
+from plone.formwidget.contenttree import ObjPathSourceBinder
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
+from zope.interface import Interface
+
+
+page_source = ObjPathSourceBinder(
+    portal_type="Document",
+)
+
+
+class IDXTypeSchema(Interface):
+
+    relation_choice = RelationChoice(
+        title=u'Relation-Choice',
+        source=page_source,
+        required=True,
+    )
+
+    relation_list = RelationList(
+        title=u'Relation-List',
+        default=[],
+        value_type=RelationChoice(
+            title=u"Relation-List",
+            source=page_source,
+            ),
+        required=True,
+        )

--- a/ftw/testbrowser/tests/profiles/dxtype.zcml
+++ b/ftw/testbrowser/tests/profiles/dxtype.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="ftw.testbrowser.tests">
+
+    <include package="Products.GenericSetup" file="meta.zcml" />
+
+    <genericsetup:registerProfile
+        name="dxtype"
+        title="ftw.testbrowser.tests:dxtype"
+        directory="dxtype"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+</configure>

--- a/ftw/testbrowser/tests/profiles/dxtype/metadata.xml
+++ b/ftw/testbrowser/tests/profiles/dxtype/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+    <version>1000</version>
+    <dependencies>
+        <dependency>profile-plone.app.dexterity:default</dependency>
+    </dependencies>
+</metadata>

--- a/ftw/testbrowser/tests/profiles/dxtype/types.xml
+++ b/ftw/testbrowser/tests/profiles/dxtype/types.xml
@@ -1,0 +1,3 @@
+<object name="portal_types">
+    <object name="DXType" meta_type="Dexterity FTI" />
+</object>

--- a/ftw/testbrowser/tests/profiles/dxtype/types/DXType.xml
+++ b/ftw/testbrowser/tests/profiles/dxtype/types/DXType.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<object name="DXType"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.testbrowser.tests" >
+
+    <!-- Basic metadata -->
+    <property name="title">DXType</property>
+    <property name="global_allow">True</property>
+    <property name="add_permission">cmf.AddPortalContent</property>
+
+    <!-- schema interface -->
+    <property name="schema">ftw.testbrowser.tests.interfaces.IDXTypeSchema</property>
+
+    <!-- class used for content items -->
+    <property name="klass">plone.dexterity.content.Item</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+    </property>
+
+    <!-- View information -->
+    <property name="default_view">view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+    <!-- Actions -->
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -2,7 +2,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
-from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING
+from ftw.testbrowser.testing import DX_TYPES_FUNCTIONAL_TESTING
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
 from plone.app.testing import SITE_OWNER_NAME
 from unittest2 import TestCase
@@ -10,7 +10,7 @@ from unittest2 import TestCase
 
 class TestDexterityForms(TestCase):
 
-    layer = PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING
+    layer = DX_TYPES_FUNCTIONAL_TESTING
 
     @browsing
     def test_tinymce_formfill(self, browser):
@@ -56,6 +56,7 @@ class TestDexterityForms(TestCase):
     def test_checkbox_values_are_preserved(self, browser):
         browser.login(SITE_OWNER_NAME).open()
         factoriesmenu.add('Page')
+
         browser.fill({'Title': u'Page',
                       'Exclude from navigation': True}).save()
         statusmessages.assert_no_error_messages()
@@ -65,3 +66,26 @@ class TestDexterityForms(TestCase):
         browser.fill({'Title': 'New Title'}).save()
         statusmessages.assert_no_error_messages()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
+
+    @browsing
+    def test_radio_button_values_are_preserved(self, browser):
+        browser.login(SITE_OWNER_NAME).open()
+        factoriesmenu.add('Page')
+        browser.fill({'Title': u'Page used as relation'}).save()
+        statusmessages.assert_no_error_messages()
+        relation = browser.context
+
+        browser.open()
+        factoriesmenu.add('DXType')
+        browser.fill({'Title': u'Content-Type with relations',
+                      'Relation-List': [relation],
+                      'Relation-Choice': relation}).save()
+        statusmessages.assert_no_error_messages()
+        self.assertEqual(relation, browser.context.relation_choice.to_object)
+        self.assertEqual(relation, browser.context.relation_list[0].to_object)
+
+        browser.find('Edit').click()
+        browser.fill({'Title': u'New Title'}).save()
+        statusmessages.assert_no_error_messages()
+        self.assertEqual(relation, browser.context.relation_choice.to_object)
+        self.assertEqual(relation, browser.context.relation_list[0].to_object)


### PR DESCRIPTION
This issue has already been fixed for checkboxes, but also appears for
radio-buttons.

The problem surfaced with relationlists/choices so i added tests for those with a custom content-type. 