### PR TITLE
Also provide advice for available options in exception message.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.19.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Also provide advice for available options in exception message.
+  [lgraf]
 
 
 1.19.1 (2015-08-20)

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -67,9 +67,14 @@ class OptionsNotFound(BrowserException):
     """Could not find the options for a widget.
     """
 
-    def __init__(self, field_label, options):
-        msg = 'Could not find options %s for field "%s".' % (
-            str(options), field_label)
+    def __init__(self, field_label, options, labels=None):
+        if labels:
+            label_advice = ' Options: "%s"' % '", "'.join(labels)
+        else:
+            label_advice = ''
+
+        msg = 'Could not find options %s for field "%s".%s' % (
+            str(options), field_label, label_advice)
         Exception.__init__(self, msg)
 
 

--- a/ftw/testbrowser/tests/test_exceptions.py
+++ b/ftw/testbrowser/tests/test_exceptions.py
@@ -21,6 +21,18 @@ class TestBrowserExceptions(TestCase):
                           str(exceptions.FormFieldNotFound('field label',
                                                            ['foo', 'bar', 'baz'])))
 
+    def test_options_not_found(self):
+        self.assertEquals(
+            'Could not find options [\'missing\'] for field "field label".',
+            str(exceptions.OptionsNotFound('field label', ['missing'])))
+
+    def test_options_not_found_with_found_options(self):
+        self.assertEquals(
+            'Could not find options [\'missing\'] for field "field label". '
+            'Options: "foo", "bar", "baz"',
+            str(exceptions.OptionsNotFound(
+                'field label', ['missing'], ['foo', 'bar', 'baz'])))
+
 
 class TestNoElementFoundException(TestCase):
 

--- a/ftw/testbrowser/tests/test_widgets_atmultiselect.py
+++ b/ftw/testbrowser/tests/test_widgets_atmultiselect.py
@@ -73,7 +73,8 @@ class TestATMultiSelectionWidget(TestCase):
             browser.fill({'Fruits': ['Banana', 'Rhubarb', 'Watermelon']})
 
         self.assertEquals('Could not find options [\'Rhubarb\']'
-                          ' for field "Fruits".',
+                          ' for field "Fruits".'
+                          ' Options: "Apple", "Banana", "Watermelon"',
                           str(cm.exception))
 
     @browsing

--- a/ftw/testbrowser/tests/test_widgets_sequence.py
+++ b/ftw/testbrowser/tests/test_widgets_sequence.py
@@ -74,5 +74,6 @@ class TestSequenceWidget(TestCase):
         with self.assertRaises(OptionsNotFound) as cm:
             browser.fill({'Fruits': ['Coconut']})
         self.assertEquals(
-            'Could not find options [\'Coconut\'] for field "Fruits".',
+            'Could not find options [\'Coconut\'] for field "Fruits".'
+            ' Options: "Apple", "Banana", "Orange"',
             str(cm.exception))

--- a/ftw/testbrowser/tests/test_widgets_z3c_choice_collection.py
+++ b/ftw/testbrowser/tests/test_widgets_z3c_choice_collection.py
@@ -200,7 +200,8 @@ class TestZ3cChoiceCollectionWidget(TestCase):
             browser.fill({'Fruits': ['Banana', 'Rhubarb', 'Watermelon']})
 
         self.assertEquals('Could not find options [\'Rhubarb\']'
-                          ' for field "Fruits".',
+                          ' for field "Fruits".'
+                          ' Options: "Apple", "Watermelon", "Banana"',
                           str(cm.exception))
 
     @browsing

--- a/ftw/testbrowser/widgets/atmultiselect.py
+++ b/ftw/testbrowser/widgets/atmultiselect.py
@@ -52,8 +52,9 @@ class ATMultiSelectionWidget(PloneWidget):
                 values.remove(input.attrib['value'])
 
         if values:
+            available_options = self.options
             raise OptionsNotFound(normalize_spaces(self.label.raw_text),
-                                  values)
+                                  values, available_options)
 
     @property
     def label(self):

--- a/ftw/testbrowser/widgets/sequence.py
+++ b/ftw/testbrowser/widgets/sequence.py
@@ -68,7 +68,9 @@ class SequenceWidget(PloneWidget):
                 values.remove(input.attrib['value'])
 
         if values:
-            raise OptionsNotFound(self.label.normalized_text(), values)
+            available_options = self.options
+            raise OptionsNotFound(
+                self.label.normalized_text(), values, available_options)
 
     @property
     def options(self):

--- a/ftw/testbrowser/widgets/z3cchoicecollection.py
+++ b/ftw/testbrowser/widgets/z3cchoicecollection.py
@@ -77,7 +77,9 @@ class Z3cChoiceCollection(PloneWidget):
                 not_found.append(value)
 
         if not_found:
-            raise OptionsNotFound(self.label.text, not_found)
+            available_options = self.options_labels
+            raise OptionsNotFound(
+                self.label.text, not_found, available_options)
 
     @property
     def options(self):


### PR DESCRIPTION
This adds the same behavior as for `FormFieldNotFound` to `OptionsNotFound` exceptions - telling the user what choices he has after yelling at him:

```python
  File "ftw/testbrowser/widgets/sequence.py", line 73, in fill
    self.label.normalized_text(), values, available_options)

OptionsNotFound: Could not find options ['Coconut'] for field "Fruits". Options: "Apple", "Banana", "Orange"
```