### PR TITLE
Preserve current zope.globalrequest request when opening pages with mechanize.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.19.2 (unreleased)
 -------------------
 
+- Preserve the request of zope.globalrequest when opening pages with
+  mechanize.
+  [deiferni]
+
 - Also provide advice for available options in exception message.
   [lgraf]
 

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -16,6 +16,8 @@ from operator import attrgetter
 from requests.structures import CaseInsensitiveDict
 from StringIO import StringIO
 from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 from zope.interface import implements
 import json
 import lxml
@@ -253,6 +255,7 @@ class Browser(object):
         """
         args = locals().copy()
         del args['self']
+        preserved_request = getRequest()
         self.previous_request = ('_open_with_mechanize', args)
         self.previous_url = self.url
 
@@ -278,6 +281,7 @@ class Browser(object):
             raise
         self.parse(self.response)
         self.previous_request_library = LIB_MECHANIZE
+        setRequest(preserved_request)
 
     def _open_with_requests(self, url, data=None, method='GET', headers=None,
                             referer=False):

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -11,6 +11,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from unittest2 import TestCase
 from zExceptions import NotFound
+from zope.globalrequest import getRequest
 
 
 AC_COOKIE_INFO = {'comment': None,
@@ -228,6 +229,17 @@ class TestBrowserCore(TestCase):
 
         browser.reload()
         self.assertEquals(TEST_USER_ID, plone.logged_in())
+
+    @browsing
+    def test_opening_preserves_global_request_MECHANIZE(self, browser):
+        browser.open()
+        self.assertIsNotNone(getRequest())
+
+    @browsing
+    def test_opening_preserves_global_request_REQUESTS(self, browser):
+        browser.request_library = LIB_REQUESTS
+        browser.open()
+        self.assertIsNotNone(getRequest())
 
     def assert_starts_with(self, start, contents):
         self.assertTrue(


### PR DESCRIPTION
Mechanize requests run in the same thread as the currently executed test. The current zope.gloablrequest request is cleared after publishing when an IPubSuccess event is fired. This breaks getRequest for the current test-case.

With these changes the current zope.gloablrequest request is preserved after opening a page.

When using `LIB_REQUESTS` no changes are required since those requests run in another thread.