### PR TITLE
add support for button tags

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - No longer test with Archetypes, test only with dexterity. [jone]
 - Support latest Plone 4.3.x release. [mathias.leimgruber]
 
+- Add Support for Button tag.
+  [tschanzt]
+
 
 1.19.3 (2016-07-25)
 -------------------

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -9,6 +9,7 @@ from ftw.testbrowser.interfaces import IBrowser
 from ftw.testbrowser.nodes import wrap_nodes
 from ftw.testbrowser.nodes import wrapped_nodes
 from ftw.testbrowser.utils import normalize_spaces
+from ftw.testbrowser.utils import parse_html
 from ftw.testbrowser.utils import verbose_logging
 from lxml.cssselect import CSSSelector
 from mechanize import Request
@@ -836,7 +837,8 @@ class Browser(object):
         :param html: The HTML to parse (default: current response).
         :type html: string
         """
-        return self._load_html(html or self.response, lxml.html.parse)
+        return self._load_html(html or self.response,
+                               parse_html)
 
     def parse_as_xml(self, xml=None):
         """Parse the response document with the XML parser.
@@ -863,7 +865,8 @@ class Browser(object):
         if self.mimetype in ('text/xml', 'application/xml'):
             return self._load_html(xml_or_html, lxml.etree.parse)
         else:
-            return self._load_html(xml_or_html, lxml.html.parse)
+            return self._load_html(xml_or_html,
+                                   parse_html)
 
     def clone(self):
         """Creates a new browser instance with a cloned state of the
@@ -937,7 +940,7 @@ class Browser(object):
 
         return url
 
-    def _load_html(self, html, parser=lxml.html.parse):
+    def _load_html(self, html, parser=parse_html):
         self.form_files = {}
 
         if hasattr(html, 'seek'):

--- a/ftw/testbrowser/nodes.py
+++ b/ftw/testbrowser/nodes.py
@@ -102,6 +102,10 @@ def wrap_node(node, browser):
         from ftw.testbrowser.form import SubmitButton
         return SubmitButton(node, browser)
 
+    if node.tag == 'button' and node.attrib.get('type', None) == 'submit':
+        from ftw.testbrowser.form import SubmitButton
+        return SubmitButton(node, browser)
+
     if node.tag == 'input' and node.attrib.get('type', None) == 'file':
         from ftw.testbrowser.form import FileField
         return FileField(node, browser)

--- a/ftw/testbrowser/parser.py
+++ b/ftw/testbrowser/parser.py
@@ -1,0 +1,21 @@
+from lxml.html import HtmlElementClassLookup
+from lxml.html import HTMLParser
+from lxml.html import InputElement
+
+
+class TestbrowserHTMLParser(HTMLParser):
+    """An HTML parser that is configured to return lxml.html Element
+    objects.
+    """
+    def __init__(self, **kwargs):
+        super(TestbrowserHTMLParser, self).__init__(**kwargs)
+        self.set_element_class_lookup(
+            TestbrowserHtmlElementClassLookup({'button': InputElement}))
+
+
+class TestbrowserHtmlElementClassLookup(HtmlElementClassLookup):
+
+    def __init__(self, classes=None, mixins=None):
+        super(TestbrowserHtmlElementClassLookup, self).__init__(None, mixins)
+        for key, value in classes.items():
+            self._element_classes[key] = value

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -14,6 +14,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from unittest2 import TestCase
+from zope.publisher.interfaces import NotFound
 import lxml.html
 
 
@@ -241,6 +242,43 @@ class TestSubmittingForms(TestCase):
             '&atext=foo&submit-button=Submit',
             browser.url)
 
+    @browsing
+    def test_find_submit_button_tag(self, browser):
+        browser.open_html(
+            '<form>'
+            '<button type="submit">blubb</button>'
+            '</form>')
+        form = browser.forms['form-0']
+        self.assertEquals(1, len(form.find_submit_buttons()))
+
+    @browsing
+    def test_find_submit_button_tag_by_label(self, browser):
+        browser.open_html(
+            '<form>'
+            '<button type="submit">blubb</button>'
+            '</form>')
+        form = browser.forms['form-0']
+        button = form.find_button_by_label('blubb')
+        self.assertTrue(button)
+        self.assertEquals('submit', button.type)
+
+    @browsing
+    def test_find_submit_button_tag_click(self, browser):
+        browser.open_html(
+            '<form action="http://nohost/plone">'
+            '<button type="submit">blubb</button>'
+            '</form>')
+        form = browser.forms['form-0']
+        button = form.find_button_by_label('blubb')
+        button.click()
+
+    @browsing
+    def test_find_submit_button_tag_in_request(self, browser):
+        browser.visit(view='test-form')
+        browser.find("novalue-button").click()
+        self.assertEquals({'textfield': '',
+                           'novalue-button': ''}, browser.json)
+
 
 class TestSelectField(TestCase):
 
@@ -376,3 +414,5 @@ class TestSelectField(TestCase):
             '</form>')
         form = browser.fill({'text': 'some text'})
         self.assertEqual({'text': 'some text'}, dict(form.values))
+
+

--- a/ftw/testbrowser/tests/views/test-form.pt
+++ b/ftw/testbrowser/tests/views/test-form.pt
@@ -12,7 +12,7 @@
                 <input name="textfield" id="textfield" value="" />
                 <input type="checkbox" name="checkbox-without-value" />
 
-                <button type="submit" name="novalue-button">&</button>
+                <button type="submit" name="novalue-button">Button without value</button>
                 <input type="submit" value="Submit" name="submit-button" />
                 <input type="submit" value="Cancel" name="cancel-button" />
             </form>

--- a/ftw/testbrowser/tests/views/test-form.pt
+++ b/ftw/testbrowser/tests/views/test-form.pt
@@ -12,6 +12,7 @@
                 <input name="textfield" id="textfield" value="" />
                 <input type="checkbox" name="checkbox-without-value" />
 
+                <button type="submit" name="novalue-button">&</button>
                 <input type="submit" value="Submit" name="submit-button" />
                 <input type="submit" value="Cancel" name="cancel-button" />
             </form>

--- a/ftw/testbrowser/utils.py
+++ b/ftw/testbrowser/utils.py
@@ -1,5 +1,7 @@
 from contextlib import contextmanager
+from ftw.testbrowser.parser import TestbrowserHTMLParser
 import logging
+import lxml
 import re
 import sys
 
@@ -16,3 +18,7 @@ def verbose_logging():
         yield
     finally:
         logging.root.removeHandler(stdouthandler)
+
+
+def parse_html(html):
+    return lxml.html.parse(html, TestbrowserHTMLParser())


### PR DESCRIPTION
@jone this adds support for the button tag. I added a subclass of the default lxml HtmlParser so we can add the <button> tag as a InputElement. Also i changed the function to use our own self.input function since i had to add the buttons there. Therefore the items were now wrapped by ftw.testbrowser.