### PR TITLE
No longer test with archetypes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.19.4 (unreleased)
 -------------------
 
+- No longer test with Archetypes, test only with dexterity. [jone]
 - Support latest Plone 4.3.x release. [mathias.leimgruber]
 
 

--- a/ftw/testbrowser/pages/folder_contents.py
+++ b/ftw/testbrowser/pages/folder_contents.py
@@ -1,6 +1,5 @@
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.nodes import wrap_nodes
-from operator import attrgetter
 from operator import itemgetter
 
 

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -1,3 +1,4 @@
+from ftw.builder.content import register_dx_content_builders
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
@@ -23,13 +24,23 @@ class BrowserLayer(PloneSandboxLayer):
             '</configure>',
             context=configurationContext)
 
+        import ftw.testbrowser.tests
+        xmlconfig.file('profiles/dxtype.zcml',
+                       ftw.testbrowser.tests,
+                       context=configurationContext)
+
         import ftw.testbrowser.tests.views
         xmlconfig.file('configure.zcml',
                        ftw.testbrowser.tests.views,
                        context=configurationContext)
 
+        z2.installProduct(app, 'Products.DateRecurringIndex')
+
     def setUpPloneSite(self, portal):
+        applyProfile(portal, 'ftw.testbrowser.tests:dxtype')
         applyProfile(portal, 'plone.formwidget.autocomplete:default')
+        applyProfile(portal, 'plone.app.contenttypes:default')
+        register_dx_content_builders(force=True)
 
 
 BROWSER_FIXTURE = BrowserLayer()
@@ -42,37 +53,3 @@ BROWSER_ZSERVER_FUNCTIONAL_TESTING = FunctionalTesting(
            set_builder_session_factory(functional_session_factory),
            PLONE_ZSERVER),
     name="ftw.testbrowser:functional:zserver")
-
-
-class DxTypesLayer(PloneSandboxLayer):
-
-    defaultBases = (PLONE_FIXTURE,)
-
-    def setUpZope(self, app, configurationContext):
-        xmlconfig.string(
-            '<configure xmlns="http://namespaces.zope.org/zope">'
-            '  <include package="z3c.autoinclude" file="meta.zcml" />'
-            '  <includePlugins package="plone" />'
-            '  <includePluginsOverrides package="plone" />'
-            '</configure>',
-            context=configurationContext)
-
-        import ftw.testbrowser.tests
-        xmlconfig.file('profiles/dxtype.zcml',
-                       ftw.testbrowser.tests,
-                       context=configurationContext)
-
-        z2.installProduct(app, 'Products.DateRecurringIndex')
-
-    def setUpPloneSite(self, portal):
-        applyProfile(
-            portal, 'ftw.testbrowser.tests:dxtype')
-
-        applyProfile(portal, 'plone.app.contenttypes:default')
-
-
-DX_TYPES_FIXTURE = DxTypesLayer()
-DX_TYPES_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(DX_TYPES_FIXTURE,
-           set_builder_session_factory(functional_session_factory)),
-    name="ftw.testbrowser:dx-functional")

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -1,12 +1,12 @@
-from ftw.testbrowser.testing import DX_TYPES_FUNCTIONAL_TESTING
+from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
 import transaction
 
 
-class DxFunctionalTestCase(TestCase):
-    layer = DX_TYPES_FUNCTIONAL_TESTING
+class FunctionalTestCase(TestCase):
+    layer = BROWSER_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -5,11 +5,11 @@ from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from unittest2 import TestCase
 from zExceptions import NotFound
 from zope.globalrequest import getRequest
 
@@ -33,8 +33,7 @@ AC_COOKIE_INFO = {'comment': None,
                   'secure': False}
 
 
-class TestBrowserCore(TestCase):
-
+class TestBrowserCore(FunctionalTestCase):
     layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
 
     @browsing

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -20,13 +20,13 @@ class TestBrowserContext(TestCase):
 
     @browsing
     def test_context_can_be_retrieved_from_current_folder(self, browser):
-        folder = create(Builder('folder').titled('The Folder'))
+        folder = create(Builder('folder').titled(u'The Folder'))
         browser.login().visit(folder)
         self.assertEquals(folder, browser.context)
 
     @browsing
     def test_context_when_on_a_view(self, browser):
-        folder = create(Builder('folder').titled('The Folder'))
+        folder = create(Builder('folder').titled(u'The Folder'))
         browser.login().visit(folder, view='folder_contents')
         self.assertEquals(folder, browser.context)
 

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -2,21 +2,14 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import ContextNotFound
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestBrowserContext(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestBrowserContext(FunctionalTestCase):
 
     def setUp(self):
-        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
-        login(self.layer['portal'], TEST_USER_NAME)
+        super(TestBrowserContext, self).setUp()
+        self.grant('Manager')
 
     @browsing
     def test_context_can_be_retrieved_from_current_folder(self, browser):

--- a/ftw/testbrowser/tests/test_cookies.py
+++ b/ftw/testbrowser/tests/test_cookies.py
@@ -1,15 +1,12 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_REQUESTS
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
 from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from unittest2 import TestCase
 
 
-class TestMechanizeCookies(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestMechanizeCookies(FunctionalTestCase):
 
     @browsing
     def test_cookies(self, browser):
@@ -24,8 +21,7 @@ class TestMechanizeCookies(TestCase):
             browser.cookies['__ac'])
 
 
-class TestZServerHeaders(TestCase):
-
+class TestZServerHeaders(FunctionalTestCase):
     layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
 
     @browsing

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -2,18 +2,16 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.testing import DX_TYPES_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
 from plone.app.testing import SITE_OWNER_NAME
-from unittest2 import TestCase
 
 
-class TestDexterityForms(TestCase):
-
-    layer = DX_TYPES_FUNCTIONAL_TESTING
+class TestDexterityForms(FunctionalTestCase):
 
     @browsing
     def test_tinymce_formfill(self, browser):
+        self.grant('Manager')
         browser.login(SITE_OWNER_NAME).open()
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page',

--- a/ftw/testbrowser/tests/test_elements.py
+++ b/ftw/testbrowser/tests/test_elements.py
@@ -1,11 +1,8 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestBrowserRequests(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestBrowserRequests(FunctionalTestCase):
 
     @browsing
     def test_find_link_by_text(self, browser):

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -6,6 +6,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testbrowser.widgets.base import PloneWidget
 from plone.app.testing import PLONE_FUNCTIONAL_TESTING
 from plone.app.testing import SITE_OWNER_NAME
@@ -16,9 +17,7 @@ from unittest2 import TestCase
 import lxml.html
 
 
-class TestBrowserForms(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestBrowserForms(FunctionalTestCase):
 
     @browsing
     def test_find_form_by_field_label(self, browser):
@@ -74,29 +73,29 @@ class TestBrowserForms(TestCase):
         self.assertEquals(TEST_USER_ID, plone.logged_in())
 
     @browsing
-    def test_fill_archetypes_field(self, browser):
+    def test_fill_field(self, browser):
         browser.login(SITE_OWNER_NAME).open()
         factoriesmenu.add('Folder')
-        browser.fill({'Title': 'The Folder'}).submit()
-        self.assertEquals('folder_listing', plone.view())
+        browser.fill({'Title': 'The Folder'}).save()
+        self.assertEquals('listing_view', plone.view())
         self.assertEquals('The Folder', plone.first_heading())
 
     @browsing
-    def test_fill_archtypes_field_with_unicode_umlauts(self, browser):
+    def test_fill_field_with_unicode_umlauts(self, browser):
         browser.login(SITE_OWNER_NAME).open()
         factoriesmenu.add('Folder')
         browser.fill({'Title': u'F\xf6lder',
-                      'Description': u'The f\xf6lder description'}).submit()
-        self.assertEquals('folder_listing', plone.view())
+                      'Summary': u'The f\xf6lder description'}).save()
+        self.assertEquals('listing_view', plone.view())
         self.assertEquals(u'F\xf6lder', plone.first_heading())
 
     @browsing
-    def test_fill_archtypes_field_with_utf8_umlauts(self, browser):
+    def test_fill_field_with_utf8_umlauts(self, browser):
         browser.login(SITE_OWNER_NAME).open()
         factoriesmenu.add('Folder')
         browser.fill({'Title': u'F\xf6lder'.encode('utf-8'),
-                      'Description': u'The f\xf6lder description'.encode('utf-8')}).submit()
-        self.assertEquals('folder_listing', plone.view())
+                      'Summary': u'The f\xf6lder description'.encode('utf-8')}).save()
+        self.assertEquals('listing_view', plone.view())
         self.assertEquals(u'F\xf6lder', plone.first_heading())
 
     @browsing
@@ -118,21 +117,12 @@ class TestBrowserForms(TestCase):
             browser.json)
 
     @browsing
-    def test_at_fill_tinymce_field(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
-        factoriesmenu.add('Page')
-        browser.fill({'Title': 'The page',
-                      'Body Text': '<p>The body text.</p>'}).submit()
-        self.assertEquals('The body text.',
-                          browser.css('#content-core').first.normalized_text())
-
-    @browsing
-    def test_at_save_add_form(self, browser):
+    def test_save_add_form(self, browser):
         browser.login(SITE_OWNER_NAME).open()
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page'}).save()
         statusmessages.assert_no_error_messages()
-        self.assertEquals('http://nohost/plone/the-page', browser.url)
+        self.assertEquals('http://nohost/plone/the-page/view', browser.url)
 
     @browsing
     def test_find_submit_buttons(self, browser):

--- a/ftw/testbrowser/tests/test_headers.py
+++ b/ftw/testbrowser/tests/test_headers.py
@@ -1,12 +1,9 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
-from unittest2 import TestCase
 
 
-class TestMechanizeHeaders(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestMechanizeHeaders(FunctionalTestCase):
 
     @browsing
     def test_headers(self, browser):
@@ -15,8 +12,7 @@ class TestMechanizeHeaders(TestCase):
                           browser.headers.get('content-type'))
 
 
-class TestZServerHeaders(TestCase):
-
+class TestZServerHeaders(FunctionalTestCase):
     layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
 
     @browsing

--- a/ftw/testbrowser/tests/test_nodes.py
+++ b/ftw/testbrowser/tests/test_nodes.py
@@ -6,13 +6,10 @@ from ftw.testbrowser.nodes import LinkNode
 from ftw.testbrowser.nodes import NodeWrapper
 from ftw.testbrowser.nodes import Nodes
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestNodesResultSet(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestNodesResultSet(FunctionalTestCase):
 
     @browsing
     def test_text_content_for_many_elements(self, browser):
@@ -269,9 +266,7 @@ class TestNodesResultSet(TestCase):
             'Reversing a "Nodes" object should not change it\'s type.')
 
 
-class TestNodeWrappers(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestNodeWrappers(FunctionalTestCase):
 
     def test_reference_to_browser(self):
         with Browser()(self.layer['app']) as browser:
@@ -685,9 +680,7 @@ class TestNodeWrappers(TestCase):
             browser.css('#text').first.normalized_outerHTML)
 
 
-class TestNodeComparison(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestNodeComparison(FunctionalTestCase):
 
     @browsing
     def test_comparing_two_elements_representing_the_same_node(self, browser):
@@ -705,9 +698,7 @@ class TestNodeComparison(TestCase):
                              'Different elements should be different.')
 
 
-class TestLinkNode(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestLinkNode(FunctionalTestCase):
 
     @browsing
     def test_clicking_links(self, browser):
@@ -731,9 +722,7 @@ class TestLinkNode(TestCase):
             str(cm.exception))
 
 
-class TestDefinitionListNode(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestDefinitionListNode(FunctionalTestCase):
 
     @browsing
     def test_keys_returns_dts(self, browser):

--- a/ftw/testbrowser/tests/test_pages_dexterity.py
+++ b/ftw/testbrowser/tests/test_pages_dexterity.py
@@ -1,10 +1,10 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import dexterity
 from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.tests import DxFunctionalTestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestDexterityPageObject(DxFunctionalTestCase):
+class TestDexterityPageObject(FunctionalTestCase):
 
     @browsing
     def test_erroneous_fields(self, browser):

--- a/ftw/testbrowser/tests/test_pages_factoriesmenu.py
+++ b/ftw/testbrowser/tests/test_pages_factoriesmenu.py
@@ -2,34 +2,23 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.pages import plone
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
-from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestFactoriesMenu(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
-
-    def setUp(self):
-        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
-        login(self.layer['portal'], TEST_USER_NAME)
+class TestFactoriesMenu(FunctionalTestCase):
 
     @browsing
     def test_factoriesmenu_visible(self, browser):
+        self.grant('Manager')
         browser.open()
         self.assertFalse(factoriesmenu.visible())
-        browser.login(SITE_OWNER_NAME).open()
+        browser.login().open()
         self.assertTrue(factoriesmenu.visible())
 
     @browsing
     def test_addable_types(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         self.assertIn('Folder', factoriesmenu.addable_types())
 
     @browsing
@@ -42,13 +31,15 @@ class TestFactoriesMenu(TestCase):
 
     @browsing
     def test_adding_content(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Folder')
-        self.assertEquals('atct_edit', plone.view())
+        self.assertEquals('http://nohost/plone/++add++Folder', browser.url)
 
     @browsing
     def test_adding_unallowed_or_missing_type(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         with self.assertRaises(ValueError) as cm:
             factoriesmenu.add('Unkown Type')
 
@@ -68,10 +59,11 @@ class TestFactoriesMenu(TestCase):
 
     @browsing
     def test_addable_types_works_with_restrictions_entry(self, browser):
+        self.grant('Manager')
         # Regression:
         # The "Restrictions..." entry in the factories menu, as it exists
         # on folders, contains unicode characters and did break everything.
         # This test verifies that this still works.
         folder = create(Builder('folder'))
-        browser.login(SITE_OWNER_NAME).visit(folder)
+        browser.login().visit(folder)
         self.assertIn(u'Restrictions\u2026', factoriesmenu.addable_types())

--- a/ftw/testbrowser/tests/test_pages_folder_contents.py
+++ b/ftw/testbrowser/tests/test_pages_folder_contents.py
@@ -18,14 +18,14 @@ class TestFolderContents(TestCase):
 
     @browsing
     def test_titles(self, browser):
-        create(Builder('page').titled('An exotic page'))
+        create(Builder('page').titled(u'An exotic page'))
         browser.login().open(view='folder_contents')
         self.assertEquals(['An exotic page'], folder_contents.titles())
 
     @browsing
     def test_select__selects_from_objects(self, browser):
-        foo = create(Builder('page').titled('Foo'))
-        bar = create(Builder('page').titled('Bar'))
+        foo = create(Builder('page').titled(u'Foo'))
+        bar = create(Builder('page').titled(u'Bar'))
 
         browser.login().open(view='folder_contents')
         folder_contents.select(foo, bar)
@@ -35,8 +35,8 @@ class TestFolderContents(TestCase):
 
     @browsing
     def test_select_by_title(self, browser):
-        create(Builder('page').titled('Foo'))
-        create(Builder('page').titled('Bar'))
+        create(Builder('page').titled(u'Foo'))
+        create(Builder('page').titled(u'Bar'))
 
         browser.login().open(view='folder_contents')
         folder_contents.select_by_title('Foo', 'Bar')
@@ -46,9 +46,9 @@ class TestFolderContents(TestCase):
 
     @browsing
     def test_select_by_path(self, browser):
-        foo = create(Builder('page').titled('Foo'))
+        foo = create(Builder('page').titled(u'Foo'))
         foo_path = '/'.join(foo.getPhysicalPath())
-        bar = create(Builder('page').titled('Bar'))
+        bar = create(Builder('page').titled(u'Bar'))
         bar_path = '/'.join(bar.getPhysicalPath())
 
         browser.login().open(view='folder_contents')
@@ -59,7 +59,7 @@ class TestFolderContents(TestCase):
 
     @browsing
     def test_row_by_title(self, browser):
-        create(Builder('page').titled('Foo'))
+        create(Builder('page').titled(u'Foo'))
         browser.login().open(view='folder_contents')
 
         with self.assertRaises(ValueError) as cm:
@@ -69,7 +69,7 @@ class TestFolderContents(TestCase):
 
         self.assertEquals(TableRow, type(folder_contents.row_by_title('Foo')))
 
-        create(Builder('page').titled('Foo'))
+        create(Builder('page').titled(u'Foo'))
         browser.reload()
         with self.assertRaises(ValueError) as cm:
             folder_contents.row_by_title('Foo')
@@ -80,8 +80,8 @@ class TestFolderContents(TestCase):
 
     @browsing
     def test_row_by_object(self, browser):
-        obj = create(Builder('folder').titled('Foo'))
-        subobj = create(Builder('page').titled('Bar').within(obj))
+        obj = create(Builder('folder').titled(u'Foo'))
+        subobj = create(Builder('page').titled(u'Bar').within(obj))
         browser.login().open(view='folder_contents')
 
         self.assertEquals(TableRow, type(folder_contents.row_by_object(obj)))
@@ -95,8 +95,8 @@ class TestFolderContents(TestCase):
 
     @browsing
     def test_row_by_path(self, browser):
-        obj = create(Builder('folder').titled('Foo'))
-        subobj = create(Builder('page').titled('Bar').within(obj))
+        obj = create(Builder('folder').titled(u'Foo'))
+        subobj = create(Builder('page').titled(u'Bar').within(obj))
         browser.login().open(view='folder_contents')
 
         obj_path = '/'.join(obj.getPhysicalPath())

--- a/ftw/testbrowser/tests/test_pages_folder_contents.py
+++ b/ftw/testbrowser/tests/test_pages_folder_contents.py
@@ -3,18 +3,14 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import folder_contents
 from ftw.testbrowser.table import TableRow
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
-from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestFolderContents(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestFolderContents(FunctionalTestCase):
 
     def setUp(self):
-        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+        super(TestFolderContents, self).setUp()
+        self.grant('Manager')
 
     @browsing
     def test_titles(self, browser):

--- a/ftw/testbrowser/tests/test_pages_plone.py
+++ b/ftw/testbrowser/tests/test_pages_plone.py
@@ -1,15 +1,12 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
-from plone.app.testing import PLONE_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
 
 
-class TestPlonePageObject(TestCase):
-
-    layer = PLONE_FUNCTIONAL_TESTING
+class TestPlonePageObject(FunctionalTestCase):
 
     @browsing
     def test_not_logged_in(self, browser):
@@ -24,7 +21,7 @@ class TestPlonePageObject(TestCase):
     @browsing
     def test_view_on_root(self, browser):
         browser.open()
-        self.assertEquals('folder_listing', plone.view())
+        self.assertEquals('listing_view', plone.view())
 
     @browsing
     def test_view_on_login_form(self, browser):
@@ -40,7 +37,7 @@ class TestPlonePageObject(TestCase):
     @browsing
     def test_view_and_portal_type(self, browser):
         browser.open()
-        self.assertEquals(('folder_listing', 'plone-site'),
+        self.assertEquals(('listing_view', 'plone-site'),
                           plone.view_and_portal_type())
 
     @browsing

--- a/ftw/testbrowser/tests/test_pages_statusmessages.py
+++ b/ftw/testbrowser/tests/test_pages_statusmessages.py
@@ -1,12 +1,9 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestStatusmessages(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestStatusmessages(FunctionalTestCase):
 
     @browsing
     def test_messages(self, browser):

--- a/ftw/testbrowser/tests/test_pages_z3cform.py
+++ b/ftw/testbrowser/tests/test_pages_z3cform.py
@@ -1,10 +1,10 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import z3cform
-from ftw.testbrowser.tests import DxFunctionalTestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestZ3cformPageObject(DxFunctionalTestCase):
+class TestZ3cformPageObject(FunctionalTestCase):
 
     @browsing
     def test_erroneous_fields(self, browser):

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -74,13 +74,13 @@ class TestMechanizeBrowserRequests(TestCase):
 
     @browsing
     def test_visit_object(self, browser):
-        folder = create(Builder('folder').titled('Test Folder'))
+        folder = create(Builder('folder').titled(u'Test Folder'))
         browser.login().visit(folder)
         self.assertEquals('http://nohost/plone/test-folder', browser.url)
 
     @browsing
     def test_visit_view_on_object(self, browser):
-        folder = create(Builder('folder').titled('Test Folder'))
+        folder = create(Builder('folder').titled(u'Test Folder'))
         browser.login().visit(folder, view='folder_contents')
         self.assertEquals('http://nohost/plone/test-folder/folder_contents',
                           browser.url)

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -8,7 +8,7 @@ from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
 from ftw.testbrowser.tests.helpers import register_view
 from plone.app.testing import TEST_USER_ID
@@ -16,13 +16,10 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.testing import login
 from plone.app.testing import setRoles
-from unittest2 import TestCase
 from zope.publisher.browser import BrowserView
 
 
-class TestMechanizeBrowserRequests(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestMechanizeBrowserRequests(FunctionalTestCase):
 
     def setUp(self):
         portal = self.layer['portal']
@@ -311,8 +308,7 @@ class TestMechanizeBrowserRequests(TestCase):
         self.assertEquals(None, browser.encoding)
 
 
-class TestRequestslibBrowserRequests(TestCase):
-
+class TestRequestslibBrowserRequests(FunctionalTestCase):
     layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/ftw/testbrowser/tests/test_session.py
+++ b/ftw/testbrowser/tests/test_session.py
@@ -1,15 +1,12 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import plone
-from plone.app.testing import PLONE_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from unittest2 import TestCase
 
 
-class TestBrowserSession(TestCase):
-
-    layer = PLONE_FUNCTIONAL_TESTING
+class TestBrowserSession(FunctionalTestCase):
 
     @browsing
     def test_browser_stays_logged_in(self, browser):

--- a/ftw/testbrowser/tests/test_tables.py
+++ b/ftw/testbrowser/tests/test_tables.py
@@ -1,14 +1,11 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.table import colspan_padded_text
 from ftw.testbrowser.table import TableCell
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from operator import attrgetter
-from unittest2 import TestCase
 
 
-class TestTables(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestTables(FunctionalTestCase):
 
     @browsing
     def test_find_cell_by_text_on_table(self, browser):
@@ -292,9 +289,7 @@ class TestTables(TestCase):
              'padded': colspan_padded_text(foot_row)})
 
 
-class TestTableRow(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestTableRow(FunctionalTestCase):
 
     @browsing
     def test_table_attribute_is_table_object(self, browser):
@@ -391,9 +386,7 @@ class TestTableRow(TestCase):
             table.column('Calories'))
 
 
-class TestTableCell(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestTableCell(FunctionalTestCase):
 
     @browsing
     def test_table_attribute_is_table_object(self, browser):

--- a/ftw/testbrowser/tests/test_webdav_requests.py
+++ b/ftw/testbrowser/tests/test_webdav_requests.py
@@ -1,13 +1,11 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import ZServerRequired
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
 from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestWebdavRequests(TestCase):
-
+class TestWebdavRequests(FunctionalTestCase):
     layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
 
     @browsing
@@ -35,9 +33,7 @@ class TestWebdavRequests(TestCase):
                           browser.xpath('//d:displayname').first.text)
 
 
-class TestNoZserverWebdavRequests(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestNoZserverWebdavRequests(FunctionalTestCase):
 
     @browsing
     def test_webdav_requires_zserver(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_autocomplete.py
+++ b/ftw/testbrowser/tests/test_widgets_autocomplete.py
@@ -1,13 +1,10 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import SITE_OWNER_NAME
-from unittest2 import TestCase
 from urlparse import urljoin
 
 
-class TestBrowserZ3CForms(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestBrowserZ3CForms(FunctionalTestCase):
 
     @browsing
     def test_autocomplete_form_fill(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_contenttree.py
+++ b/ftw/testbrowser/tests/test_widgets_contenttree.py
@@ -1,23 +1,15 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
-from unittest2 import TestCase
 
 
-class TestContentTreeWidget(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestContentTreeWidget(FunctionalTestCase):
 
     def setUp(self):
-        portal = self.layer['portal']
-        setRoles(portal, TEST_USER_ID, ['Manager'])
-        login(portal, TEST_USER_NAME)
+        super(TestContentTreeWidget, self).setUp()
+        self.grant('Manager')
 
     @browsing
     def test_selecting_object(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_contenttree.py
+++ b/ftw/testbrowser/tests/test_widgets_contenttree.py
@@ -21,8 +21,8 @@ class TestContentTreeWidget(TestCase):
 
     @browsing
     def test_selecting_object(self, browser):
-        foo = create(Builder('document').titled('Foo'))
-        bar = create(Builder('document').titled('Bar'))
+        foo = create(Builder('document').titled(u'Foo'))
+        bar = create(Builder('document').titled(u'Bar'))
 
         browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
         browser.fill({'Documents': (foo, bar)})
@@ -33,7 +33,7 @@ class TestContentTreeWidget(TestCase):
 
     @browsing
     def test_querying_objects(self, browser):
-        create(Builder('document').titled('The Document'))
+        create(Builder('document').titled(u'The Document'))
 
         browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
 

--- a/ftw/testbrowser/tests/test_widgets_datagrid.py
+++ b/ftw/testbrowser/tests/test_widgets_datagrid.py
@@ -1,17 +1,14 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testing import staticuid
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
 import transaction
 
 
-class TestDexterityDataGridWidget(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestDexterityDataGridWidget(FunctionalTestCase):
 
     @browsing
     @staticuid()

--- a/ftw/testbrowser/tests/test_widgets_date.py
+++ b/ftw/testbrowser/tests/test_widgets_date.py
@@ -1,13 +1,10 @@
 from datetime import date
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import SITE_OWNER_NAME
-from unittest2 import TestCase
 
 
-class TestDateWidget(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestDateWidget(FunctionalTestCase):
 
     @browsing
     def test_z3cform_datefield_formfill(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_datetime.py
+++ b/ftw/testbrowser/tests/test_widgets_datetime.py
@@ -1,35 +1,30 @@
-from DateTime import DateTime
 from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import SITE_OWNER_NAME
-from unittest2 import TestCase
 
 
-class TestDatetimeWidget(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestDatetimeWidget(FunctionalTestCase):
 
     @browsing
     def test_z3cform_formfill(self, browser):
         browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
-        browser.fill({'Delivery date': datetime(2010, 12, 22, 10, 30, 00)})
+        browser.fill({'Delivery date': datetime(2010, 12, 22, 10, 30, 0)})
         browser.find('Submit').click()
         self.assertEquals({u'delivery_date': u'2010-12-22T10:30:00'},
                           browser.json)
 
     @browsing
-    def test_archetypes_formfill(self, browser):
+    def test_formfill(self, browser):
         browser.login(SITE_OWNER_NAME).open()
         factoriesmenu.add('Event')
         browser.fill({'Title': 'Event',
-                      'Event Starts': datetime(2010, 5, 3, 23, 30, 00),
-                      'Event Ends': datetime(2010, 12, 23, 10, 05, 00)})
+                      'Event Starts': datetime(2010, 5, 3, 23, 30, 0),
+                      'Event Ends': datetime(2010, 12, 23, 10, 5, 0)})
         browser.find('Save').click()
 
-        event = self.layer['portal'].restrictedTraverse('event')
-        self.assertEquals(DateTime('2010/05/03 23:30:00'),
-                          event.Schema()['startDate'].get(event))
-        self.assertEquals(DateTime('2010/12/23 10:05:00'),
-                          event.Schema()['endDate'].get(event))
+        self.assertEquals(['2010-05-03T23:30:00+02:00'],
+                          browser.css('li.dtstart').text)
+        self.assertEquals(['2010-12-23T10:05:00+01:00'],
+                          browser.css('li.dtend').text)

--- a/ftw/testbrowser/tests/test_widgets_file.py
+++ b/ftw/testbrowser/tests/test_widgets_file.py
@@ -1,43 +1,12 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.tests import DxFunctionalTestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testbrowser.tests.helpers import asset
-from plone.app.testing import PLONE_FUNCTIONAL_TESTING
 from plone.app.testing import SITE_OWNER_NAME
-from unittest2 import TestCase
 
 
-class TestArchetypesFileUploadWidget(TestCase):
-
-    layer = PLONE_FUNCTIONAL_TESTING
-
-    @browsing
-    def test_filling_file_upload_widget_by_label(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
-        factoriesmenu.add('File')
-        browser.fill({'Title': 'The file',
-                      'File': ('file data', 'file.txt')}).submit()
-
-        browser.find('file.txt').click()
-        self.assertEquals('file data', browser.contents)
-
-    @browsing
-    def test_filling_image_upload_widget_by_label(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
-        factoriesmenu.add('Image')
-
-        with asset('mario.gif') as mario:
-            browser.fill({'Image': (mario.read(), 'mario.gif')}).submit()
-
-        browser.find('Download').click()
-        self.assertEquals('attachment; filename="mario.gif"',
-                          browser.headers.get('Content-Disposition'))
-        self.assertEquals('image/gif',
-                          browser.headers.get('Content-Type'))
-
-
-class TestDexterityFileUploadWidget(DxFunctionalTestCase):
+class TestDexterityFileUploadWidget(FunctionalTestCase):
 
     @browsing
     def test_filling_file_upload_widget_by_label(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_sequence.py
+++ b/ftw/testbrowser/tests/test_widgets_sequence.py
@@ -1,14 +1,11 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import OnlyOneValueAllowed
 from ftw.testbrowser.exceptions import OptionsNotFound
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
 from plone.app.testing import SITE_OWNER_NAME
-from unittest2 import TestCase
 
 
-class TestSequenceWidget(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestSequenceWidget(FunctionalTestCase):
 
     @browsing
     def test_sequence_widget_options(self, browser):

--- a/ftw/testbrowser/tests/test_xml_document.py
+++ b/ftw/testbrowser/tests/test_xml_document.py
@@ -1,10 +1,8 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
-from unittest2 import TestCase
+from ftw.testbrowser.tests import FunctionalTestCase
 
 
-class TestXMLDocument(TestCase):
-    layer = BROWSER_FUNCTIONAL_TESTING
+class TestXMLDocument(FunctionalTestCase):
 
     @browsing
     def test_utf8_document_with_umlaut(self, browser):

--- a/ftw/testbrowser/widgets/datetime.py
+++ b/ftw/testbrowser/widgets/datetime.py
@@ -25,8 +25,8 @@ class DateTimeWidget(PloneWidget):
         :type value: :py:class:`datetime.datetime`
         """
 
-        self._field('day').value = value.strftime('%d')
-        self._field('month').value = value.strftime('%m')
+        self._field('day').value = value.strftime('%-d')
+        self._field('month').value = value.strftime('%-m')
         self._field('year').value = value.strftime('%Y')
 
         if not self._field('hour'):


### PR DESCRIPTION
In preparation for supporting Plone 5 we are switching all tests to Dexterity and do no longer really test with Archetypes.

We keep the Archetypes code there, so that Plone 4 tests might or might not work with newer teststbrowsers.