### PR TITLE
Introduce request drivers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.20.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Refactoring: introduce request drivers. [jone]
 
 
 1.20.0 (2017-04-10)

--- a/docs/source/api_browser.rst
+++ b/docs/source/api_browser.rst
@@ -3,10 +3,45 @@
  Browser
 =========
 
+.. contents:: :local:
+
 .. automodule:: ftw.testbrowser
    :show-inheritance:
    :members:
 
 .. automodule:: ftw.testbrowser.core
+   :show-inheritance:
+   :members:
+
+
+Drivers
+=======
+
+Drivers are responsible for making the request and responding to basic
+questions, such as the current URL or response headers.
+
+.. automodule:: ftw.testbrowser.drivers
+
+
+RequestsDriver
+--------------
+
+.. autoclass:: ftw.testbrowser.drivers.requestsdriver.RequestsDriver
+   :show-inheritance:
+   :members:
+
+
+MechanizeDriver
+---------------
+
+.. autoclass:: ftw.testbrowser.drivers.mechdriver.MechanizeDriver
+   :show-inheritance:
+   :members:
+
+
+StaticDriver
+------------
+
+.. autoclass:: ftw.testbrowser.drivers.staticdriver.StaticDriver
    :show-inheritance:
    :members:

--- a/ftw/testbrowser/drivers/mechdriver.py
+++ b/ftw/testbrowser/drivers/mechdriver.py
@@ -1,0 +1,175 @@
+from ftw.testbrowser.drivers.utils import remembering_for_reload
+from ftw.testbrowser.exceptions import BlankPage
+from ftw.testbrowser.exceptions import BrowserNotSetUpException
+from ftw.testbrowser.interfaces import IDriver
+from ftw.testbrowser.utils import copy_docs_from_interface
+from mechanize import Request
+from requests.structures import CaseInsensitiveDict
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
+from zope.interface import implements
+import pkg_resources
+import urllib
+
+
+try:
+    pkg_resources.get_distribution('zope.testbrowser')
+except pkg_resources.DistributionNotFound:
+    HAS_PLONE_EXTRAS = False
+else:
+    HAS_PLONE_EXTRAS = True
+    from plone.testing._z2_testbrowser import Zope2MechanizeBrowser
+
+
+@copy_docs_from_interface
+class MechanizeDriver(object):
+    """The mechanize driver uses the Mechanize browser with
+    plone.testing integration for making the requests.
+    """
+    implements(IDriver)
+
+    LIBRARY_NAME = 'mechanize library'
+
+    def __init__(self, browser):
+        self.browser = browser
+        self.reset()
+
+    def reset(self):
+        self.response = None
+        self.mechbrowser = None
+        self.previous_make_request = None
+
+    @remembering_for_reload
+    def make_request(self, method, url, data=None, headers=None,
+                     referer_url=None):
+        preserved_request = getRequest()
+
+        data = self._prepare_post_data(data)
+        request = Request(url, data)
+        if referer_url:
+            self._add_headers_to_request(request,
+                                         {'REFERER': referer_url,
+                                          'HTTP_REFERER': referer_url})
+
+        self._add_headers_to_request(request, headers)
+
+        try:
+            self.response = self._get_mechbrowser().open(request)
+        except:
+            self.response = None
+            raise
+        setRequest(preserved_request)
+        return self.response
+
+    def reload(self):
+        if self.previous_make_request is None:
+            raise BlankPage('Cannot reload.')
+        return self.previous_make_request()
+
+    def get_response_body(self):
+        if self.response is None:
+            raise BlankPage()
+
+        self.response.seek(0)
+        return self.response.read()
+
+    def get_url(self):
+        if self.response is None:
+            return None
+        return self._get_mechbrowser().geturl()
+
+    def get_response_headers(self):
+        if getattr(self.response, 'info', None) is not None:
+            return CaseInsensitiveDict(self.response.info().items())
+        else:
+            return {}
+
+    def get_response_cookies(self):
+        cookies = {}
+        cookiejar = self._get_mechbrowser()._ua_handlers["_cookies"].cookiejar
+        for cookie in cookiejar:
+            cookies[cookie.name] = vars(cookie)
+        return cookies
+
+    def append_request_header(self, name, value):
+        try:
+            self._get_mechbrowser().addheaders.append((name, value))
+        except BrowserNotSetUpException:
+            pass
+
+    def clear_request_header(self, name):
+        try:
+            addheaders = self._get_mechbrowser().addheaders
+        except BrowserNotSetUpException:
+            pass
+        else:
+            for header_name, value in addheaders[:]:
+                if header_name == name:
+                    addheaders.remove((header_name, value))
+
+    def cloned(self, subbrowser):
+        subdriver = subbrowser.get_driver(self.LIBRARY_NAME)
+        subdriver._get_mechbrowser().set_cookiejar(
+            self._get_mechbrowser()._ua_handlers['_cookies'].cookiejar)
+
+    def _get_mechbrowser(self):
+        if not HAS_PLONE_EXTRAS:
+            raise ImportError(
+                'Could not import zope.testbrowser.'
+                ' Please install ftw.testbrowser[plone] extras.')
+
+        if self.browser.app is None:
+            raise BrowserNotSetUpException()
+
+        if self.mechbrowser is None:
+            self.mechbrowser = Zope2MechanizeBrowser(self.browser.app)
+            self._get_mechbrowser().addheaders.append((
+                'X-zope-handle-errors', 'False'))
+        return self.mechbrowser
+
+    def _prepare_post_data(self, data):
+        if not data:
+            return None
+
+        if isinstance(data, (str, unicode)):
+            # We already have a payload, e.g. a MIME request.
+            return data
+
+        if isinstance(data, dict):
+            data = data.items()
+
+        normalized_data = []
+        for name, value_or_values in data:
+            if isinstance(name, unicode):
+                name = name.encode('utf-8')
+
+            if isinstance(value_or_values, (list, tuple, set)):
+                values = value_or_values
+            else:
+                values = [value_or_values]
+
+            for value in values:
+                if isinstance(value, unicode):
+                    value = value.encode('utf-8')
+
+                normalized_data.append((name, value))
+
+        return urllib.urlencode(normalized_data)
+
+    def _add_headers_to_request(self, request, headers):
+        if headers is None:
+            return
+
+        if isinstance(headers, dict):
+            headers = headers.items()
+
+        for key, val in headers:
+            add_hdr = request.add_header
+            if key.lower() == "content-type":
+                try:
+                    add_hdr = request.add_unredirected_header
+                except AttributeError:
+                    # pre-2.4 and not using ClientCookie
+                    pass
+
+            add_hdr(key, val)

--- a/ftw/testbrowser/drivers/requestsdriver.py
+++ b/ftw/testbrowser/drivers/requestsdriver.py
@@ -1,0 +1,98 @@
+from ftw.testbrowser.drivers.utils import remembering_for_reload
+from ftw.testbrowser.exceptions import BlankPage
+from ftw.testbrowser.exceptions import ZServerRequired
+from ftw.testbrowser.interfaces import IDriver
+from ftw.testbrowser.utils import copy_docs_from_interface
+from ftw.testbrowser.utils import verbose_logging
+from StringIO import StringIO
+from zope.interface import implements
+import requests
+import urlparse
+
+
+@copy_docs_from_interface
+class RequestsDriver(object):
+    """The requests driver uses the "requests" library for making
+    real requests.
+    """
+    implements(IDriver)
+
+    LIBRARY_NAME = 'requests library'
+
+    def __init__(self, browser):
+        self.browser = browser
+        self.reset()
+
+    def reset(self):
+        self.response = None
+        self.previous_make_request = None
+        self.requests_session = requests.Session()
+
+    @remembering_for_reload
+    def make_request(self, method, url, data=None, headers=None,
+                     referer_url=None):
+        if urlparse.urlparse(url).hostname == 'nohost':
+            raise ZServerRequired()
+
+        if headers is None:
+            headers = {}
+
+        if referer_url and referer_url.strip():
+            headers['REFERER'] = referer_url
+            headers['HTTP_REFERER'] = referer_url
+
+        with verbose_logging():
+            try:
+                self.response = self.requests_session.request(
+                    method, url, data=data, headers=headers)
+            except:
+                self.response = None
+
+        return StringIO(self.response.content)
+
+    def reload(self):
+        if self.previous_make_request is None:
+            raise BlankPage('Cannot reload.')
+        return self.previous_make_request()
+
+    def get_response_body(self):
+        if self.response is None:
+            raise BlankPage()
+        return self.response.content
+
+    def get_url(self):
+        if self.response is None:
+            return None
+        return self.response.url
+
+    def get_response_headers(self):
+        if self.response is None:
+            return {}
+        return self.response.headers
+
+    def get_response_cookies(self):
+        cookies = {}
+        cookiejar = self.requests_session.cookies
+        for domain_cookies in cookiejar._cookies.values():
+            for path_cookies in domain_cookies.values():
+                for cookie_name, cookie in path_cookies.items():
+                    cookies[cookie_name] = vars(cookie)
+        return cookies
+
+    def append_request_header(self, name, value):
+        if name in self.requests_session.headers:
+            raise NameError(
+                ('There is already a header "{}" and the requests driver'
+                 ' does not support using the same header multiple times.')
+                .format(name))
+
+        self.requests_session.headers.update({name: value.strip()})
+
+    def clear_request_header(self, name):
+        if name in self.requests_session.headers:
+            del self.requests_session.headers[name]
+
+    def cloned(self, subbrowser):
+        subdriver = subbrowser.get_driver(self.LIBRARY_NAME)
+        requests.cookies.merge_cookies(subdriver.requests_session.cookies,
+                                       self.requests_session.cookies)

--- a/ftw/testbrowser/drivers/staticdriver.py
+++ b/ftw/testbrowser/drivers/staticdriver.py
@@ -1,0 +1,57 @@
+from ftw.testbrowser.exceptions import BlankPage
+from ftw.testbrowser.interfaces import IDriver
+from ftw.testbrowser.utils import copy_docs_from_interface
+from zope.interface import implements
+
+
+@copy_docs_from_interface
+class StaticDriver(object):
+    """The static driver can load static HTML without doing an actual request.
+    It does not support making requests at all.
+    """
+    implements(IDriver)
+
+    LIBRARY_NAME = 'static driver'
+
+    def __init__(self, browser):
+        self.browser = browser
+        self.reset()
+
+    def reset(self):
+        self.body = None
+
+    def set_body(self, body):
+        self.body = body
+
+    def make_request(self, method, url, data=None, headers=None,
+                     referer_url=None):
+        raise NotImplementedError(
+            'The StaticDriver does not support making requests.')
+
+    def reload(self):
+        if self.body is None:
+            raise BlankPage('Cannot reload.')
+        return self.body
+
+    def get_response_body(self):
+        if self.body is None:
+            raise BlankPage()
+        return self.body
+
+    def get_url(self):
+        return None
+
+    def get_response_headers(self):
+        return {}
+
+    def get_response_cookies(self):
+        return {}
+
+    def append_request_header(self, name, value):
+        pass
+
+    def clear_request_header(self, name):
+        pass
+
+    def cloned(self, subbrowser):
+        pass

--- a/ftw/testbrowser/drivers/utils.py
+++ b/ftw/testbrowser/drivers/utils.py
@@ -1,0 +1,14 @@
+from functools import partial
+
+
+def remembering_for_reload(func):
+    """Decorator which stores the method call into ``self.previous_make_request``
+    so that it can be called later for a reload.
+    The arguments are stored too, so that ``self.previous_make_request()`` can
+    be used without arguments for having the same request.
+    """
+    def wrapper(self, *args, **kwargs):
+        wrappedfunc = getattr(self, func.__name__)
+        self.previous_make_request = partial(wrappedfunc, *args, **kwargs)
+        return func(self, *args, **kwargs)
+    return wrapper

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -1,12 +1,9 @@
 from collections import defaultdict
-from ftw.testbrowser.core import LIB_MECHANIZE
-from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.exceptions import FormFieldNotFound
 from ftw.testbrowser.nodes import NodeWrapper
 from ftw.testbrowser.nodes import wrapped_nodes
 from ftw.testbrowser.utils import normalize_spaces
 from ftw.testbrowser.widgets.base import PloneWidget
-from mechanize import Request
 from mechanize._form import MimeWriter
 from StringIO import StringIO
 import lxml.html.formfill
@@ -332,39 +329,13 @@ class Form(NodeWrapper):
                 URL += '?' + urllib.urlencode(values)
             return self.browser.open(URL, referer=True)
 
-        if self.browser.request_library == LIB_MECHANIZE:
-            return self._make_mechanize_multipart_request(URL, values)
-        elif self.browser.request_library == LIB_REQUESTS:
-            return self._make_requests_multipart_request(URL, values)
-        else:
-            raise ValueError('Unkown request library: {0}'.format(
-                    self.browser.request_library))
-
-    def _make_mechanize_multipart_request(self, url, values):
         request_body, request_headers = self._prepare_multipart_request(
-            url, values)
-
-        request = Request(url, request_body)
-        for key, val in request_headers:
-            add_hdr = request.add_header
-            if key.lower() == "content-type":
-                try:
-                    add_hdr = request.add_unredirected_header
-                except AttributeError:
-                    # pre-2.4 and not using ClientCookie
-                    pass
-            add_hdr(key, val)
-
-        return self.browser._open_with_mechanize(request, referer=True)
-
-    def _make_requests_multipart_request(self, url, values):
-        request_body, request_headers = self._prepare_multipart_request(
-            url, values)
-        return self.browser._open_with_requests(url,
-                                                data=request_body,
-                                                headers=dict(request_headers),
-                                                method='POST',
-                                                referer=True)
+            URL, values)
+        return self.browser.open(URL,
+                                 data=request_body,
+                                 headers=dict(request_headers),
+                                 method='POST',
+                                 referer=True)
 
     def _prepare_multipart_request(self, URL, values):
         data = StringIO()

--- a/ftw/testbrowser/interfaces.py
+++ b/ftw/testbrowser/interfaces.py
@@ -16,3 +16,116 @@ class IBrowser(Interface):
         ``view`` - a view name (string or unicode), which is appended to the
         URL. This is especially useful combined with passing in objects.
         """
+
+
+class IDriver(Interface):
+    """A driver's job is to make requests and to provide informations about
+    the response.
+    A driver instance is reused for multiple tests / sessions.
+    """
+
+    def __init__(browser):
+        """A driver is initialized with the browser instance as argument.
+
+        :param browser: The browser object.
+        :type browser: :py:class:`ftw.testbrowser.core.Browser`
+        """
+
+    def reset():
+        """Resets the driver: closes active sessions and resets the
+        internal state.
+        """
+
+    def make_request(method, url, data=None, headers=None, referer_url=None):
+        """Make a request to the url and return the response body as string.
+
+        :param method: The HTTP request method, all uppercase.
+        :type method: string
+        :param url: A full qualified URL.
+        :type url: string
+        :param data: A dict with data which is posted using a ``POST`` request,
+          or the raw request body as a string.
+        :type data: dict or string
+        :param headers: A dict with custom headers for this request.
+        :type headers: dict
+        :param referer_url: The referer URL or ``None``.
+        :type referer: string or ``None``
+        :returns: Response body
+        :rtype: string
+        """
+
+    def reload():
+        """Reloads the current page by redoing the previous request with
+        the same arguments.
+        This applies for GET as well as POST requests.
+
+        :raises: :py:exc:`ftw.testbrowser.exceptions.BlankPage`
+        :returns: Response body
+        :rtype: string
+        """
+
+    def get_response_body():
+        """Returns the response body of the last response.
+
+        :raises: :py:exc:`ftw.testbrowser.exceptions.BlankPage`
+        :returns: Response body
+        :rtype: string
+        """
+
+    def get_url():
+        """Returns the current url, if we are on a page, or None.
+
+        :returns: the current URL
+        :rtype: string or None
+        """
+
+    def get_response_headers():
+        """Returns a dict-like object containing the response headers.
+        Returns an empty dict if there is no response.
+
+        :returns: Response header dict
+        :rtype: dict
+        """
+
+    def get_response_cookies():
+        """Retruns a dict-like object containing the cookies set by the
+        last response.
+
+        :returns: Response cookies dict
+        :rtype: dict
+        """
+
+    def append_request_header(name, value):
+        """Add a new permanent request header which is sent with every request
+        until it is cleared.
+
+        HTTP allows multiple request headers with the same name.
+        Therefore this method does not replace existing names.
+        Use ``replace_request_header`` for replacing headers.
+
+        Be aware that the ``requests`` library does not support multiple
+        headers with the same name, therefore it is always a replace
+        for the requests module.
+
+        :param name: Name of the request header
+        :type name: string
+        :param value: Value of the request header
+        :type value: string
+        """
+
+    def clear_request_header(name):
+        """Removes a permanent header.
+        If there is no such header, the removal is silently skipped.
+
+        :param name: Name of the request header as positional argument
+        :type name: string
+        """
+
+    def cloned(subbrowser):
+        """When a browser was cloned, this method is called on each
+        driver instance so that the instance can do whatever is needed
+        to have a cloned state too.
+
+        :param subbrowser: The cloned subbrowser instance.
+        :type subbrowser: :py:class:`ftw.testbrowser.core.Browser`
+        """

--- a/ftw/testbrowser/tests/test_drivers_mechdriver.py
+++ b/ftw/testbrowser/tests/test_drivers_mechdriver.py
@@ -1,0 +1,10 @@
+from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
+from ftw.testbrowser.interfaces import IDriver
+from unittest2 import TestCase
+from zope.interface.verify import verifyClass
+
+
+class TestMechanizeDriverImplementation(TestCase):
+
+    def test_implements_interface(self):
+        verifyClass(IDriver, MechanizeDriver)

--- a/ftw/testbrowser/tests/test_drivers_requestsdriver.py
+++ b/ftw/testbrowser/tests/test_drivers_requestsdriver.py
@@ -1,0 +1,27 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.drivers.requestsdriver import RequestsDriver
+from ftw.testbrowser.interfaces import IDriver
+from ftw.testbrowser.tests import FunctionalTestCase
+from zope.interface.verify import verifyClass
+
+
+class TestRequestsDriverImplementation(FunctionalTestCase):
+
+    def test_implements_interface(self):
+        verifyClass(IDriver, RequestsDriver)
+
+    @browsing
+    def test_does_not_support_duplicate_request_headers(self, browser):
+        browser.request_library = LIB_REQUESTS
+        browser.get_driver()
+
+        browser.append_request_header('Authorization', 'Basic foo:foo')
+
+        with self.assertRaises(NameError) as cm:
+            browser.append_request_header('Authorization', 'Basic foo:bar')
+
+        self.assertEquals(
+            'There is already a header "Authorization" and the requests driver'
+            ' does not support using the same header multiple times.',
+            str(cm.exception))

--- a/ftw/testbrowser/tests/test_drivers_staticdriver.py
+++ b/ftw/testbrowser/tests/test_drivers_staticdriver.py
@@ -1,0 +1,10 @@
+from ftw.testbrowser.drivers.staticdriver import StaticDriver
+from ftw.testbrowser.interfaces import IDriver
+from unittest2 import TestCase
+from zope.interface.verify import verifyClass
+
+
+class TestStaticDriverImplementation(TestCase):
+
+    def test_implements_interface(self):
+        verifyClass(IDriver, StaticDriver)

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -194,7 +194,7 @@ class TestBrowserForms(FunctionalTestCase):
         url = self.layer['portal'].absolute_url() + '/folder_contents'
 
         browser.login(SITE_OWNER_NAME).open(url)
-        browser.open_html(
+        browser.parse(
             '<html>'
             ' <form id="form"></form>'
             '</html>')
@@ -263,7 +263,8 @@ class TestSubmittingForms(TestCase):
 
     @browsing
     def test_find_submit_button_tag_click(self, browser):
-        browser.open_html(
+        browser.open()
+        browser.parse(
             '<form action="http://nohost/plone">'
             '<button type="submit">blubb</button>'
             '</form>')
@@ -413,5 +414,3 @@ class TestSelectField(TestCase):
             '</form>')
         form = browser.fill({'text': 'some text'})
         self.assertEqual({'text': 'some text'}, dict(form.values))
-
-

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -136,19 +136,18 @@ class TestMechanizeBrowserRequests(FunctionalTestCase):
 
     @browsing
     def test_open_html_sets_response_to_html_stream(self, browser):
-        # When an exception happens within a test, the response content is dumped
-        # to a temporary file for debugging purpose.
-        # For having the HTML, which was set with open_html, in the temporary file
-        # the response needs to contain this HTML and not html set previously or
-        # nothing.
+        """
+        When an exception happens within a test, the response content is dumped
+        to a temporary file for debugging purpose.
+        In order for that to work, browser.contents must be the HTML body.
+        """
 
         html = '\n'.join(('<html>',
                           '<h1>The heading</h1>',
                           '<html>'))
 
         browser.open_html(html)
-        browser.response.seek(0)
-        self.assertEquals(html, browser.response.read())
+        self.assertEquals(html, browser.contents)
 
     @browsing
     def test_logout_works(self, browser):
@@ -256,7 +255,8 @@ class TestMechanizeBrowserRequests(FunctionalTestCase):
 
     @browsing
     def test_fill_and_submit_multi_select_form(self, browser):
-        browser.open_html(
+        browser.open()
+        browser.parse(
             '\n'.join(('<form action="{0}">'.format(self.json_view_url),
                        '<select name="selectfield" multiple="multiple">',
                        '<option>Foo</option>',
@@ -318,22 +318,22 @@ class TestRequestslibBrowserRequests(FunctionalTestCase):
     @browsing
     def test_open_supports_choosing_library_when_doing_request(self, browser):
         browser.open(library=LIB_MECHANIZE)
-        self.assertEquals('mechanize',
-                          browser.response.__class__.__module__.split('.')[0])
+        self.assertEquals('MechanizeDriver',
+                          type(browser.get_driver()).__name__)
 
         browser.open(library=LIB_REQUESTS)
-        self.assertEquals('requests',
-                          browser.response.__class__.__module__.split('.')[0])
+        self.assertEquals('RequestsDriver',
+                          type(browser.get_driver()).__name__)
 
     @browsing
     def test_visit_supports_choosing_library_when_doing_request(self, browser):
         browser.visit(library=LIB_MECHANIZE)
-        self.assertEquals('mechanize',
-                          browser.response.__class__.__module__.split('.')[0])
+        self.assertEquals('MechanizeDriver',
+                          type(browser.get_driver()).__name__)
 
         browser.visit(library=LIB_REQUESTS)
-        self.assertEquals('requests',
-                          browser.response.__class__.__module__.split('.')[0])
+        self.assertEquals('RequestsDriver',
+                          type(browser.get_driver()).__name__)
 
     @browsing
     def test_url_with_requests_libr(self, browser):
@@ -344,8 +344,8 @@ class TestRequestslibBrowserRequests(FunctionalTestCase):
     def test_no_browser_setup_uses_requests_library(self):
         with Browser() as browser:
             browser.open(self.layer['portal'].absolute_url())
-            self.assertEquals('requests',
-                              browser.response.__class__.__module__.split('.')[0])
+            self.assertEquals('RequestsDriver',
+                              type(browser.get_driver()).__name__)
 
     def test_form_submitting_with_requests_library(self):
         with Browser() as browser:
@@ -458,8 +458,8 @@ class TestRequestslibBrowserRequests(FunctionalTestCase):
 
     @browsing
     def test_fill_and_submit_multi_select_form(self, browser):
-        browser.request_library = LIB_REQUESTS
-        browser.open_html(
+        browser.open(library=LIB_REQUESTS)
+        browser.parse(
             '\n'.join(('<form action="{0}">'.format(self.json_view_url),
                        '<select name="selectfield" multiple="multiple">',
                        '<option>Foo</option>',

--- a/ftw/testbrowser/tests/test_webdav_requests.py
+++ b/ftw/testbrowser/tests/test_webdav_requests.py
@@ -16,7 +16,7 @@ class TestWebdavRequests(FunctionalTestCase):
     @browsing
     def test_options_request(self, browser):
         browser.webdav('OPTIONS')
-        self.assertEquals('1,2', browser.response.headers.get('DAV'))
+        self.assertEquals('1,2', browser.headers.get('DAV'))
 
     @browsing
     def test_propfind_request(self, browser):

--- a/ftw/testbrowser/utils.py
+++ b/ftw/testbrowser/utils.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from ftw.testbrowser.parser import TestbrowserHTMLParser
+from zope.interface.declarations import implementedBy
 import logging
 import lxml
 import re
@@ -22,3 +23,16 @@ def verbose_logging():
 
 def parse_html(html):
     return lxml.html.parse(html, TestbrowserHTMLParser())
+
+
+def copy_docs_from_interface(klass):
+    """Class decorator for copying the method documentation from the only
+    implemented interface to the actual method function documentation.
+    This makes it possible to autodoc it in sphinx documentation.
+    """
+
+    iface, = implementedBy(klass)
+    for name, spec in iface.namesAndDescriptions():
+        getattr(klass, name).im_func.__doc__ = spec.__doc__
+
+    return klass


### PR DESCRIPTION
Introduce a new concept of request drivers, which are responsible for making requests and for responding to questions regarding the state and the response.

The current implementation already supports ``Mechanize``, ``requests`` library and setting static HTML, resulting in three standard drivers.

The mechanism for switching the driver is the same as switching the request library before this change.

The browser API did not change regarding tested public API. Things such as accessing the last response directly with ``browser.response`` is no longer possible though.
This is a refactoring: the goal is to have as few impact as possible.

The goal of this change is to make it is to add new drivers, which I plan to do shortly.