### PR TITLE
add default_driver option.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.20.1 (unreleased)
 -------------------
 
+- Add ``default_driver`` option to the driver. [jone]
 - Refactoring: introduce request drivers. [jone]
 
 

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -47,6 +47,26 @@ a new browser and to set it up manually:
    browser manually will not set it as global browser and page objects / forms will
    not be able to access it!
 
+Choosing the default driver
+---------------------------
+
+The default driver is chosen automatically, depending on whether the browser is
+set up with a zope app (=> ``LIB_MECHANIZE``) or not (=> ``LIB_REQUESTS``).
+The default driver can be changed on the browser instance, overriding the
+automatic driver selection:
+
+.. code:: py
+
+    from ftw.testbrowser.core import Browser
+    from ftw.testbrowser.core import LIB_MECHANIZE
+    from ftw.testbrowser.core import LIB_REQUESTS
+
+    browser = Browser()
+    # always use mechanize:
+    browser.default_driver = LIB_MECHANIZE
+
+    # or always use requests:
+    browser.default_driver = LIB_REQUESTS
 
 
 Visit pages

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -86,6 +86,7 @@ class Browser(object):
 
     def __init__(self):
         self.drivers = {}
+        self.default_driver = None
         self.reset()
 
     def __call__(self, app):
@@ -114,7 +115,9 @@ class Browser(object):
 
     def __enter__(self):
         if self.request_library is None:
-            if self.next_app is None:
+            if self.default_driver is not None:
+                self.request_library = self.default_driver
+            elif self.next_app is None:
                 self.request_library = LIB_REQUESTS
             else:
                 self.request_library = LIB_MECHANIZE

--- a/ftw/testbrowser/tests/test_defaultdriver.py
+++ b/ftw/testbrowser/tests/test_defaultdriver.py
@@ -1,0 +1,29 @@
+from ftw.testbrowser import Browser
+from ftw.testbrowser.core import LIB_MECHANIZE
+from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.tests import FunctionalTestCase
+
+
+class TestDefaultDriver(FunctionalTestCase):
+
+    def test_library_constants_without_zopeapp(self):
+        browser = Browser()
+
+        browser.default_driver = LIB_REQUESTS
+        with browser:
+            self.assertEquals(LIB_REQUESTS, browser.get_driver().LIBRARY_NAME)
+
+        browser.default_driver = LIB_MECHANIZE
+        with browser:
+            self.assertEquals(LIB_MECHANIZE, browser.get_driver().LIBRARY_NAME)
+
+    def test_library_constants_with_zopeapp(self):
+        browser = Browser()
+
+        browser.default_driver = LIB_REQUESTS
+        with browser(self.layer['app']):
+            self.assertEquals(LIB_REQUESTS, browser.get_driver().LIBRARY_NAME)
+
+        browser.default_driver = LIB_MECHANIZE
+        with browser(self.layer['app']):
+            self.assertEquals(LIB_MECHANIZE, browser.get_driver().LIBRARY_NAME)


### PR DESCRIPTION
The ``default_driver`` option allows to set the default driver for all upcoming sessions on a browser instance.