### PR TITLE
🚧 Add testing layers for setting the default driver.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.20.1 (unreleased)
 -------------------
 
+- Add testing layers for setting the default driver. [jone]
 - Add ``default_driver`` option to the driver. [jone]
 - Refactoring: introduce request drivers. [jone]
 

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -69,6 +69,30 @@ automatic driver selection:
     browser.default_driver = LIB_REQUESTS
 
 
+When using the testbrowser in a ``plone.testing`` layer, the driver can be
+chosen by using a standard ``plone.testing`` fixture:
+
+.. code:: py
+
+    from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
+    from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
+    from plone.app.testing import PLONE_FIXTURE
+    from plone.app.testing import FunctionalTesting
+
+
+    MY_FUNCTIONAL_TESTING_WITH_MECHANIZE = FunctionalTesting(
+        bases=(PLONE_FIXTURE,
+               MECHANIZE_BROWSER_FIXTURE),
+        name='functional:mechanize')
+
+    MY_FUNCTIONAL_TESTING_WITH_REQUESTS = FunctionalTesting(
+        bases=(PLONE_FIXTURE,
+               REQUESTS_BROWSER_FIXTURE),
+        name='functional:requests')
+
+
+
+
 Visit pages
 ===========
 

--- a/ftw/testbrowser/__init__.py
+++ b/ftw/testbrowser/__init__.py
@@ -1,4 +1,7 @@
 from ftw.testbrowser.core import Browser
+from ftw.testbrowser.core import LIB_MECHANIZE
+from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.drivers.layers import DefaultDriverFixture
 
 
 #: The singleton browser instance acting as default browser.
@@ -32,3 +35,10 @@ def browsing(func):
             return func(self, *args, **kwargs)
     test_function.__name__ = func.__name__
     return test_function
+
+
+#: A plone.testing layer which sets the default driver to Mechanize.
+MECHANIZE_BROWSER_FIXTURE = DefaultDriverFixture(LIB_MECHANIZE)
+
+#: A plone.testing layer which sets the default driver to Requests.
+REQUESTS_BROWSER_FIXTURE = DefaultDriverFixture(LIB_REQUESTS)

--- a/ftw/testbrowser/drivers/layers.py
+++ b/ftw/testbrowser/drivers/layers.py
@@ -1,0 +1,18 @@
+from plone.testing import Layer
+
+
+class DefaultDriverFixture(Layer):
+
+    def __init__(self, library_constant):
+        super(DefaultDriverFixture, self).__init__(
+            name='DefaultDriverFixture:{}'.format(library_constant))
+        self.library_constant = library_constant
+
+    def setUp(self):
+        from ftw.testbrowser import browser
+        self.previous_default_driver = browser.default_driver
+        browser.default_driver = self.library_constant
+
+    def tearDown(self):
+        from ftw.testbrowser import browser
+        browser.default_driver = self.previous_default_driver

--- a/ftw/testbrowser/tests/test_driver_layers.py
+++ b/ftw/testbrowser/tests/test_driver_layers.py
@@ -1,0 +1,32 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
+from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
+from ftw.testbrowser.core import LIB_MECHANIZE
+from ftw.testbrowser.core import LIB_REQUESTS
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import PLONE_FIXTURE
+from unittest2 import TestCase
+
+
+class TestMechanizeFixture(TestCase):
+
+    layer = FunctionalTesting(
+        bases=(PLONE_FIXTURE,
+               MECHANIZE_BROWSER_FIXTURE),
+        name='functional:mechanize')
+
+    @browsing
+    def test(self, browser):
+        self.assertEquals(LIB_MECHANIZE, browser.get_driver().LIBRARY_NAME)
+
+
+class TestRequestsFixture(TestCase):
+
+    layer = FunctionalTesting(
+        bases=(PLONE_FIXTURE,
+               REQUESTS_BROWSER_FIXTURE),
+        name='functional:requests')
+
+    @browsing
+    def test(self, browser):
+        self.assertEquals(LIB_REQUESTS, browser.get_driver().LIBRARY_NAME)


### PR DESCRIPTION
🚧 _bases on #42 ; rebase and change target branch when #42 is merged_

The testbrowser now provides a ``MECHANIZE_BROWSER_FIXTURE`` and a ``REQUESTS_BROWSER_FIXTURE`` for as base for a testing layer.
These layers set the default driver for the layer lifetime.