### PR TITLE
🚧 run tests against all drivers.

### DIFF
--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -58,7 +58,7 @@ class NoElementFound(BrowserException):
 
 
 class ZServerRequired(BrowserException):
-    """The `webdav` method can only be used with a running ZServer.
+    """The requests driver can only be used with a running ZServer.
     Use the `plone.app.testing.PLONE_ZSERVER` testing layer.
     """
 

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -2,6 +2,8 @@ from ftw.builder.content import register_dx_content_builders
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
+from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -44,12 +46,18 @@ class BrowserLayer(PloneSandboxLayer):
 
 
 BROWSER_FIXTURE = BrowserLayer()
-BROWSER_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(BROWSER_FIXTURE,
-           set_builder_session_factory(functional_session_factory)),
-    name="ftw.testbrowser:functional")
-BROWSER_ZSERVER_FUNCTIONAL_TESTING = FunctionalTesting(
+
+MECHANIZE_TESTING = FunctionalTesting(
     bases=(BROWSER_FIXTURE,
            set_builder_session_factory(functional_session_factory),
-           PLONE_ZSERVER),
-    name="ftw.testbrowser:functional:zserver")
+           MECHANIZE_BROWSER_FIXTURE),
+    name='ftw.testbrowser:functional:mechanize')
+
+REQUESTS_TESTING = FunctionalTesting(
+    bases=(BROWSER_FIXTURE,
+           set_builder_session_factory(functional_session_factory),
+           PLONE_ZSERVER,
+           REQUESTS_BROWSER_FIXTURE),
+    name='ftw.testbrowser:functional:requests')
+
+DEFAULT_TESTING = MECHANIZE_TESTING

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -1,4 +1,4 @@
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
@@ -6,11 +6,18 @@ import transaction
 
 
 class FunctionalTestCase(TestCase):
-    layer = BROWSER_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']
 
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, list(roles))
-        transaction.commit()
+        if isinstance(self.layer, FunctionalTesting):
+            transaction.commit()
+
+    def sync_transaction(self):
+        # Especially with the requests driver we sometimes need to sync
+        # the transaction in order to get hold of new transactions committed
+        # on another thread.
+        if isinstance(self.layer, FunctionalTesting):
+            transaction.begin()

--- a/ftw/testbrowser/tests/alldrivers.py
+++ b/ftw/testbrowser/tests/alldrivers.py
@@ -1,0 +1,68 @@
+from ftw.testbrowser.core import LIB_MECHANIZE
+from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.testing import MECHANIZE_TESTING
+from ftw.testbrowser.testing import REQUESTS_TESTING
+from unittest2 import skip
+import sys
+
+
+def all_drivers(testcase):
+    """Decorator for test classes so that the tests are run against all drivers.
+    """
+
+    module = sys.modules[testcase.__module__]
+    drivers = (('Mechanize', MECHANIZE_TESTING, LIB_MECHANIZE),
+               ('Requests', REQUESTS_TESTING, LIB_REQUESTS))
+    testcase._testbrowser_abstract_testclass = True
+
+    for postfix, layer, constant in drivers:
+        name = testcase.__name__ + postfix
+        custom = {'layer': layer,
+                  '__module__': testcase.__module__,
+                  '_testbrowser_abstract_testclass': False}
+
+        subclass = type(name, (testcase,), custom)
+        for attrname in dir(subclass):
+            method = getattr(subclass, attrname, None)
+            func = getattr(method, 'im_func', None)
+            if getattr(func, '_testbrowser_skip_driver', None) == constant:
+                reason = func._testbrowser_skip_reason
+                setattr(subclass, attrname, skip(reason)(method))
+
+        setattr(module, name, subclass)
+
+    setattr(module, 'load_tests', load_tests)
+    return testcase
+
+
+def skip_driver(driver_constant, reason):
+    """When the test class is for "all_drivers", the "skip_driver" decorator
+    allows to skip one test method for one driver.
+    """
+    def decorator(func):
+        func._testbrowser_skip_driver = driver_constant
+        func._testbrowser_skip_reason = reason
+        return func
+    return decorator
+
+
+def load_tests(loader, tests, _):
+    """The load_tests function is copied into each test using the all_drivers
+    decorator, so that it can filter out the original base class from the test
+    discover while keeping it in the globals so that superclass calls keep
+    working.
+    """
+    result = []
+
+    for test_suite in tests:
+        if not tuple(test_suite):
+            # empty
+            continue
+
+        test_class = type(tuple(test_suite)[0])
+        if getattr(test_class, '_testbrowser_abstract_testclass', False):
+            # skip abstract class
+            continue
+
+        result.append(test_suite)
+    return loader.suiteClass(result)

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -3,8 +3,10 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import ContextNotFound
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestBrowserContext(FunctionalTestCase):
 
     def setUp(self):

--- a/ftw/testbrowser/tests/test_cookies.py
+++ b/ftw/testbrowser/tests/test_cookies.py
@@ -1,12 +1,14 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.core import LIB_REQUESTS
-from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
+from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.alldrivers import skip_driver
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 
 
-class TestMechanizeCookies(FunctionalTestCase):
+@all_drivers
+class TestCookies(FunctionalTestCase):
 
     @browsing
     def test_cookies(self, browser):
@@ -21,24 +23,11 @@ class TestMechanizeCookies(FunctionalTestCase):
             browser.cookies['__ac'])
 
 
-class TestZServerHeaders(FunctionalTestCase):
-    layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
-
-    @browsing
-    def test_cookies(self, browser):
-        browser.open(view='login_form')
-        browser.fill({'Login Name': TEST_USER_NAME,
-                      'Password': TEST_USER_PASSWORD}).submit()
-
-        self.assertIn('__ac', browser.cookies)
-        self.assertDictContainsSubset(
-            {'expires': None,
-             'path': '/'},
-            browser.cookies['__ac'])
-
+    @skip_driver(LIB_MECHANIZE, """
+    The `webdav` method can only be used with a running ZServer.
+    """)
     @browsing
     def test_webdav_cookies(self, browser):
-        browser.request_library = LIB_REQUESTS
         browser.open(view='login_form')
         browser.fill({'Login Name': TEST_USER_NAME,
                       'Password': TEST_USER_PASSWORD}).submit()

--- a/ftw/testbrowser/tests/test_defaultdriver.py
+++ b/ftw/testbrowser/tests/test_defaultdriver.py
@@ -1,10 +1,14 @@
 from ftw.testbrowser import Browser
+from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.testing import DEFAULT_TESTING
+from ftw.testbrowser.testing import REQUESTS_TESTING
 from ftw.testbrowser.tests import FunctionalTestCase
 
 
 class TestDefaultDriver(FunctionalTestCase):
+    layer = DEFAULT_TESTING
 
     def test_library_constants_without_zopeapp(self):
         browser = Browser()
@@ -27,3 +31,27 @@ class TestDefaultDriver(FunctionalTestCase):
         browser.default_driver = LIB_MECHANIZE
         with browser(self.layer['app']):
             self.assertEquals(LIB_MECHANIZE, browser.get_driver().LIBRARY_NAME)
+
+
+class TestSwitchToRequestDriver(FunctionalTestCase):
+    layer = REQUESTS_TESTING
+
+    @browsing
+    def test_open_supports_choosing_library_when_doing_request(self, browser):
+        browser.open(library=LIB_MECHANIZE)
+        self.assertEquals('MechanizeDriver',
+                          type(browser.get_driver()).__name__)
+
+        browser.open(library=LIB_REQUESTS)
+        self.assertEquals('RequestsDriver',
+                          type(browser.get_driver()).__name__)
+
+    @browsing
+    def test_visit_supports_choosing_library_when_doing_request(self, browser):
+        browser.visit(library=LIB_MECHANIZE)
+        self.assertEquals('MechanizeDriver',
+                          type(browser.get_driver()).__name__)
+
+        browser.visit(library=LIB_REQUESTS)
+        self.assertEquals('RequestsDriver',
+                          type(browser.get_driver()).__name__)

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -3,10 +3,12 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
 from plone.app.testing import SITE_OWNER_NAME
 
 
+@all_drivers
 class TestDexterityForms(FunctionalTestCase):
 
     @browsing
@@ -25,7 +27,9 @@ class TestDexterityForms(FunctionalTestCase):
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page'}).save()
         statusmessages.assert_no_error_messages()
-        self.assertEquals('http://nohost/plone/the-page/view', browser.url)
+        self.assertEquals('/'.join((self.layer['portal'].absolute_url(),
+                                    'the-page/view')),
+                          browser.url)
 
     @browsing
     def test_fill_umlauts(self, browser):
@@ -42,12 +46,14 @@ class TestDexterityForms(FunctionalTestCase):
         browser.fill({'Title': u'Page',
                       'Exclude from navigation': True}).save()
         statusmessages.assert_no_error_messages()
+        self.sync_transaction()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
         browser.find('Edit').click()
         browser.fill({'Title': 'New Title',
                              'Exclude from navigation': False}).save()
         statusmessages.assert_no_error_messages()
+        self.sync_transaction()
         self.assertFalse(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
     @browsing
@@ -58,11 +64,13 @@ class TestDexterityForms(FunctionalTestCase):
         browser.fill({'Title': u'Page',
                       'Exclude from navigation': True}).save()
         statusmessages.assert_no_error_messages()
+        self.sync_transaction()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
         browser.find('Edit').click()
         browser.fill({'Title': 'New Title'}).save()
         statusmessages.assert_no_error_messages()
+        self.sync_transaction()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
     @browsing
@@ -71,6 +79,7 @@ class TestDexterityForms(FunctionalTestCase):
         factoriesmenu.add('Page')
         browser.fill({'Title': u'Page used as relation'}).save()
         statusmessages.assert_no_error_messages()
+        self.sync_transaction()
         relation = browser.context
 
         browser.open()
@@ -79,11 +88,13 @@ class TestDexterityForms(FunctionalTestCase):
                       'Relation-List': [relation],
                       'Relation-Choice': relation}).save()
         statusmessages.assert_no_error_messages()
+        self.sync_transaction()
         self.assertEqual(relation, browser.context.relation_choice.to_object)
         self.assertEqual(relation, browser.context.relation_list[0].to_object)
 
         browser.find('Edit').click()
         browser.fill({'Title': u'New Title'}).save()
         statusmessages.assert_no_error_messages()
+        self.sync_transaction()
         self.assertEqual(relation, browser.context.relation_choice.to_object)
         self.assertEqual(relation, browser.context.relation_list[0].to_object)

--- a/ftw/testbrowser/tests/test_drivers_requestsdriver.py
+++ b/ftw/testbrowser/tests/test_drivers_requestsdriver.py
@@ -2,11 +2,13 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.drivers.requestsdriver import RequestsDriver
 from ftw.testbrowser.interfaces import IDriver
+from ftw.testbrowser.testing import DEFAULT_TESTING
 from ftw.testbrowser.tests import FunctionalTestCase
 from zope.interface.verify import verifyClass
 
 
 class TestRequestsDriverImplementation(FunctionalTestCase):
+    layer = DEFAULT_TESTING
 
     def test_implements_interface(self):
         verifyClass(IDriver, RequestsDriver)

--- a/ftw/testbrowser/tests/test_elements.py
+++ b/ftw/testbrowser/tests/test_elements.py
@@ -1,8 +1,10 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
-class TestBrowserRequests(FunctionalTestCase):
+@all_drivers
+class TestBrowserRequestsMechanize(FunctionalTestCase):
 
     @browsing
     def test_find_link_by_text(self, browser):

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -5,18 +5,17 @@ from ftw.testbrowser.form import Form
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.widgets.base import PloneWidget
-from plone.app.testing import PLONE_FUNCTIONAL_TESTING
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from unittest2 import TestCase
 import lxml.html
 
 
+@all_drivers
 class TestBrowserForms(FunctionalTestCase):
 
     @browsing
@@ -122,7 +121,8 @@ class TestBrowserForms(FunctionalTestCase):
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page'}).save()
         statusmessages.assert_no_error_messages()
-        self.assertEquals('http://nohost/plone/the-page/view', browser.url)
+        self.assertEquals(browser.url,
+                          self.portal.portal_url() + '/the-page/view')
 
     @browsing
     def test_find_submit_buttons(self, browser):
@@ -204,9 +204,8 @@ class TestBrowserForms(FunctionalTestCase):
         self.assertEquals(url, form.action_url)
 
 
-class TestSubmittingForms(TestCase):
-
-    layer = BROWSER_FUNCTIONAL_TESTING
+@all_drivers
+class TestSubmittingForms(FunctionalTestCase):
 
     @browsing
     def test_should_send_default_submit_button_value(self, browser):
@@ -237,8 +236,8 @@ class TestSubmittingForms(TestCase):
                            'formmethod': 'GET',
                            'submit-button': 'Submit'}, browser.json)
         self.assertEquals(
-            'http://nohost/plone/test-form-result?formmethod=GET'
-            '&atext=foo&submit-button=Submit',
+            '{}/test-form-result?formmethod=GET&atext=foo&submit-button=Submit'
+            .format(self.portal.portal_url()),
             browser.url)
 
     @browsing
@@ -265,7 +264,7 @@ class TestSubmittingForms(TestCase):
     def test_find_submit_button_tag_click(self, browser):
         browser.open()
         browser.parse(
-            '<form action="http://nohost/plone">'
+            '<form action="{}">'.format(self.portal.portal_url()) +
             '<button type="submit">blubb</button>'
             '</form>')
         form = browser.forms['form-0']
@@ -280,9 +279,8 @@ class TestSubmittingForms(TestCase):
                            'novalue-button': ''}, browser.json)
 
 
-class TestSelectField(TestCase):
-
-    layer = PLONE_FUNCTIONAL_TESTING
+@all_drivers
+class TestSelectField(FunctionalTestCase):
 
     @browsing
     def test_select_value(self, browser):

--- a/ftw/testbrowser/tests/test_headers.py
+++ b/ftw/testbrowser/tests/test_headers.py
@@ -1,26 +1,23 @@
 from ftw.testbrowser import browsing
+from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.tests import FunctionalTestCase
-from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.alldrivers import skip_driver
 
 
+@all_drivers
 class TestMechanizeHeaders(FunctionalTestCase):
 
     @browsing
     def test_headers(self, browser):
         browser.open()
-        self.assertEquals('text/html; charset=utf-8',
-                          browser.headers.get('content-type'))
+        self.assertIn(browser.headers.get('content-type'),
+                      ('text/html; charset=utf-8',
+                       'text/html;charset=utf-8'))
 
-
-class TestZServerHeaders(FunctionalTestCase):
-    layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
-
-    @browsing
-    def test_headers(self, browser):
-        browser.open()
-        self.assertEquals('text/html; charset=utf-8',
-                          browser.headers.get('content-type'))
-
+    @skip_driver(LIB_MECHANIZE, """
+    The `webdav` method can only be used with a running ZServer.
+    """)
     @browsing
     def test_webdav_headers(self, browser):
         browser.webdav('get')

--- a/ftw/testbrowser/tests/test_nodes.py
+++ b/ftw/testbrowser/tests/test_nodes.py
@@ -3,12 +3,14 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.form import Form
 from ftw.testbrowser.nodes import LinkNode
-from ftw.testbrowser.nodes import NodeWrapper
 from ftw.testbrowser.nodes import Nodes
+from ftw.testbrowser.nodes import NodeWrapper
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestNodesResultSet(FunctionalTestCase):
 
     @browsing
@@ -266,6 +268,7 @@ class TestNodesResultSet(FunctionalTestCase):
             'Reversing a "Nodes" object should not change it\'s type.')
 
 
+@all_drivers
 class TestNodeWrappers(FunctionalTestCase):
 
     def test_reference_to_browser(self):
@@ -680,6 +683,7 @@ class TestNodeWrappers(FunctionalTestCase):
             browser.css('#text').first.normalized_outerHTML)
 
 
+@all_drivers
 class TestNodeComparison(FunctionalTestCase):
 
     @browsing
@@ -698,6 +702,7 @@ class TestNodeComparison(FunctionalTestCase):
                              'Different elements should be different.')
 
 
+@all_drivers
 class TestLinkNode(FunctionalTestCase):
 
     @browsing
@@ -722,6 +727,7 @@ class TestLinkNode(FunctionalTestCase):
             str(cm.exception))
 
 
+@all_drivers
 class TestDefinitionListNode(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_pages_dexterity.py
+++ b/ftw/testbrowser/tests/test_pages_dexterity.py
@@ -2,8 +2,10 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import dexterity
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestDexterityPageObject(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_pages_factoriesmenu.py
+++ b/ftw/testbrowser/tests/test_pages_factoriesmenu.py
@@ -3,8 +3,10 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestFactoriesMenu(FunctionalTestCase):
 
     @browsing
@@ -34,7 +36,7 @@ class TestFactoriesMenu(FunctionalTestCase):
         self.grant('Manager')
         browser.login().open()
         factoriesmenu.add('Folder')
-        self.assertEquals('http://nohost/plone/++add++Folder', browser.url)
+        self.assertEquals(self.portal.portal_url() + '/++add++Folder', browser.url)
 
     @browsing
     def test_adding_unallowed_or_missing_type(self, browser):

--- a/ftw/testbrowser/tests/test_pages_folder_contents.py
+++ b/ftw/testbrowser/tests/test_pages_folder_contents.py
@@ -4,8 +4,10 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import folder_contents
 from ftw.testbrowser.table import TableRow
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestFolderContents(FunctionalTestCase):
 
     def setUp(self):
@@ -70,8 +72,8 @@ class TestFolderContents(FunctionalTestCase):
         with self.assertRaises(ValueError) as cm:
             folder_contents.row_by_title('Foo')
         self.assertEquals(
-            'More than one row with title "Foo" found: '
-            "['http://nohost/plone/foo', 'http://nohost/plone/foo-1']",
+            'More than one row with title "Foo" found: ' +
+            "['{0}/foo', '{0}/foo-1']".format(self.portal.portal_url()),
             str(cm.exception))
 
     @browsing

--- a/ftw/testbrowser/tests/test_pages_plone.py
+++ b/ftw/testbrowser/tests/test_pages_plone.py
@@ -2,20 +2,22 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 
 
+@all_drivers
 class TestPlonePageObject(FunctionalTestCase):
 
     @browsing
     def test_not_logged_in(self, browser):
-        browser.open('http://nohost/plone')
+        browser.open(self.portal.portal_url())
         self.assertFalse(plone.logged_in())
 
     @browsing
     def test_logged_in(self, browser):
-        browser.login().open('http://nohost/plone')
+        browser.login().open(self.portal.portal_url())
         self.assertEquals(TEST_USER_ID, plone.logged_in())
 
     @browsing

--- a/ftw/testbrowser/tests/test_pages_statusmessages.py
+++ b/ftw/testbrowser/tests/test_pages_statusmessages.py
@@ -1,8 +1,10 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestStatusmessages(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_pages_z3cform.py
+++ b/ftw/testbrowser/tests/test_pages_z3cform.py
@@ -2,8 +2,10 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import z3cform
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestZ3cformPageObject(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_referer.py
+++ b/ftw/testbrowser/tests/test_referer.py
@@ -1,13 +1,11 @@
 from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
-from ftw.testbrowser.core import LIB_REQUESTS
-from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from unittest2 import TestCase
 
 
-class TestRefererMechanizeLib(TestCase):
-
-    layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
+@all_drivers
+class TestReferer(TestCase):
 
     @browsing
     def test_no_referer_on_first_visit(self, browser):
@@ -51,9 +49,3 @@ class TestRefererMechanizeLib(TestCase):
     def assert_referer(self, expected):
         self.assertEquals(expected,
                           browser.json['HEADERS'].get('REFERER', ''))
-
-
-class TestRefererRequestsLib(TestRefererMechanizeLib):
-
-    def setUp(self):
-        browser.request_library = LIB_REQUESTS

--- a/ftw/testbrowser/tests/test_session.py
+++ b/ftw/testbrowser/tests/test_session.py
@@ -1,11 +1,13 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 
 
+@all_drivers
 class TestBrowserSession(FunctionalTestCase):
 
     @browsing
@@ -31,4 +33,4 @@ class TestBrowserSession(FunctionalTestCase):
     def test_previous_url_is_set_on_link_click(self, browser):
         browser.open()
         browser.find('Log in').click()
-        self.assertEquals('http://nohost/plone', browser.previous_url)
+        self.assertEquals(self.portal.portal_url(), browser.previous_url)

--- a/ftw/testbrowser/tests/test_tables.py
+++ b/ftw/testbrowser/tests/test_tables.py
@@ -2,9 +2,11 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.table import colspan_padded_text
 from ftw.testbrowser.table import TableCell
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from operator import attrgetter
 
 
+@all_drivers
 class TestTables(FunctionalTestCase):
 
     @browsing
@@ -289,6 +291,7 @@ class TestTables(FunctionalTestCase):
              'padded': colspan_padded_text(foot_row)})
 
 
+@all_drivers
 class TestTableRow(FunctionalTestCase):
 
     @browsing
@@ -386,6 +389,7 @@ class TestTableRow(FunctionalTestCase):
             table.column('Calories'))
 
 
+@all_drivers
 class TestTableCell(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_webdav_requests.py
+++ b/ftw/testbrowser/tests/test_webdav_requests.py
@@ -1,12 +1,13 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import ZServerRequired
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.testing import BROWSER_ZSERVER_FUNCTIONAL_TESTING
+from ftw.testbrowser.testing import MECHANIZE_TESTING
+from ftw.testbrowser.testing import REQUESTS_TESTING
 from ftw.testbrowser.tests import FunctionalTestCase
 
 
 class TestWebdavRequests(FunctionalTestCase):
-    layer = BROWSER_ZSERVER_FUNCTIONAL_TESTING
+    layer = REQUESTS_TESTING
 
     @browsing
     def test_login_works(self, browser):
@@ -34,6 +35,7 @@ class TestWebdavRequests(FunctionalTestCase):
 
 
 class TestNoZserverWebdavRequests(FunctionalTestCase):
+    layer = MECHANIZE_TESTING
 
     @browsing
     def test_webdav_requires_zserver(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_autocomplete.py
+++ b/ftw/testbrowser/tests/test_widgets_autocomplete.py
@@ -1,9 +1,11 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 from urlparse import urljoin
 
 
+@all_drivers
 class TestBrowserZ3CForms(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_widgets_contenttree.py
+++ b/ftw/testbrowser/tests/test_widgets_contenttree.py
@@ -2,9 +2,11 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
+@all_drivers
 class TestContentTreeWidget(FunctionalTestCase):
 
     def setUp(self):

--- a/ftw/testbrowser/tests/test_widgets_datagrid.py
+++ b/ftw/testbrowser/tests/test_widgets_datagrid.py
@@ -2,12 +2,14 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testing import staticuid
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 import transaction
 
 
+@all_drivers
 class TestDexterityDataGridWidget(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_widgets_date.py
+++ b/ftw/testbrowser/tests/test_widgets_date.py
@@ -1,9 +1,11 @@
 from datetime import date
 from ftw.testbrowser import browsing
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
+@all_drivers
 class TestDateWidget(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_widgets_datetime.py
+++ b/ftw/testbrowser/tests/test_widgets_datetime.py
@@ -2,9 +2,11 @@ from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
+@all_drivers
 class TestDatetimeWidget(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_widgets_file.py
+++ b/ftw/testbrowser/tests/test_widgets_file.py
@@ -2,10 +2,12 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import asset
 from plone.app.testing import SITE_OWNER_NAME
 
 
+@all_drivers
 class TestDexterityFileUploadWidget(FunctionalTestCase):
 
     @browsing
@@ -27,5 +29,6 @@ class TestDexterityFileUploadWidget(FunctionalTestCase):
             browser.fill({'Image': (mario.read(), 'mario.gif')}).save()
         statusmessages.assert_message('Item created')
 
+        self.sync_transaction()
         browser.open(browser.context, view='@@images/image.gif')
         self.assertEquals('image/gif', browser.headers.get('Content-Type'))

--- a/ftw/testbrowser/tests/test_widgets_sequence.py
+++ b/ftw/testbrowser/tests/test_widgets_sequence.py
@@ -2,9 +2,11 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import OnlyOneValueAllowed
 from ftw.testbrowser.exceptions import OptionsNotFound
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
+@all_drivers
 class TestSequenceWidget(FunctionalTestCase):
 
     @browsing

--- a/ftw/testbrowser/tests/test_xml_document.py
+++ b/ftw/testbrowser/tests/test_xml_document.py
@@ -1,7 +1,9 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
+@all_drivers
 class TestXMLDocument(FunctionalTestCase):
 
     @browsing


### PR DESCRIPTION
🚧 _bases on #43 ; rebase and change target branch when #43 is merged_

Add a ``@all_drivers`` directive for marking test classes to be ran against all default drivers.
By doing that we run much more tests against the requests library implementation.
It allows us to ensure the quality of future drivers.