### PR TITLE
make zope.globalrequest support optional.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.20.1 (unreleased)
 -------------------
 
+- Make ``zope.globalrequest`` support optional. [jone]
 - Add testing layers for setting the default driver. [jone]
 - Add ``default_driver`` option to the driver. [jone]
 - Refactoring: introduce request drivers. [jone]

--- a/ftw/testbrowser/drivers/mechdriver.py
+++ b/ftw/testbrowser/drivers/mechdriver.py
@@ -1,3 +1,4 @@
+from ftw.testbrowser.drivers.utils import isolated
 from ftw.testbrowser.drivers.utils import remembering_for_reload
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
@@ -5,8 +6,6 @@ from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.utils import copy_docs_from_interface
 from mechanize import Request
 from requests.structures import CaseInsensitiveDict
-from zope.globalrequest import getRequest
-from zope.globalrequest import setRequest
 from zope.interface import implements
 import pkg_resources
 import urllib
@@ -40,9 +39,9 @@ class MechanizeDriver(object):
         self.previous_make_request = None
 
     @remembering_for_reload
+    @isolated
     def make_request(self, method, url, data=None, headers=None,
                      referer_url=None):
-        preserved_request = getRequest()
 
         data = self._prepare_post_data(data)
         request = Request(url, data)
@@ -58,7 +57,6 @@ class MechanizeDriver(object):
         except:
             self.response = None
             raise
-        setRequest(preserved_request)
         return self.response
 
     def reload(self):

--- a/ftw/testbrowser/drivers/utils.py
+++ b/ftw/testbrowser/drivers/utils.py
@@ -1,4 +1,17 @@
+from contextlib import contextmanager
 from functools import partial
+from functools import wraps
+import pkg_resources
+
+
+try:
+    pkg_resources.get_distribution('zope.globalrequest')
+except pkg_resources.DistributionNotFound:
+    HAS_GLOBALREQUEST = False
+else:
+    HAS_GLOBALREQUEST = True
+    from zope.globalrequest import getRequest
+    from zope.globalrequest import setRequest
 
 
 def remembering_for_reload(func):
@@ -7,8 +20,37 @@ def remembering_for_reload(func):
     The arguments are stored too, so that ``self.previous_make_request()`` can
     be used without arguments for having the same request.
     """
+    @wraps(func)
     def wrapper(self, *args, **kwargs):
         wrappedfunc = getattr(self, func.__name__)
         self.previous_make_request = partial(wrappedfunc, *args, **kwargs)
         return func(self, *args, **kwargs)
     return wrapper
+
+
+def isolated(func):
+    """Decorator for isolating the environment within a function.
+    Isolates:
+    - globalrequest
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with isolate_globalrequest():
+            return func(*args, **kwargs)
+    return wrapper
+
+
+@contextmanager
+def isolate_globalrequest():
+    """Context manager for global request isolation.
+    """
+    if not HAS_GLOBALREQUEST:
+        yield
+        return
+
+    request = getRequest()
+    setRequest(None)
+    try:
+        yield
+    finally:
+        setRequest(request)

--- a/ftw/testbrowser/tests/test_driver_utils.py
+++ b/ftw/testbrowser/tests/test_driver_utils.py
@@ -1,0 +1,31 @@
+from ftw.testbrowser.drivers.utils import isolate_globalrequest
+from ftw.testbrowser.drivers.utils import isolated
+from ftw.testbrowser.testing import DEFAULT_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
+
+
+class TestIsolation(FunctionalTestCase):
+    layer = DEFAULT_TESTING
+
+    def test_decorator_isolates_globalrequest(self):
+        setRequest(self.layer['request'])
+
+        @isolated
+        def foo():
+            self.assertIsNone(None, getRequest())
+            setRequest('bar')
+            return 'Foo'
+
+        self.assertEquals('Foo', foo())
+        self.assertEquals(self.layer['request'], getRequest())
+
+    def test_isolate_globalrequest(self):
+        setRequest(self.layer['request'])
+
+        with isolate_globalrequest():
+            self.assertIsNone(None, getRequest())
+            setRequest('bar')
+
+        self.assertEquals(self.layer['request'], getRequest())

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ tests_require = [
     'z3c.relationfield',
     'zExceptions',
     'zope.configuration',
+    'zope.globalrequest',
     'zope.publisher',
     'zope.schema',
     ]
@@ -73,7 +74,6 @@ setup(name='ftw.testbrowser',
         'setuptools',
         'zope.component',
         'zope.deprecation',
-        'zope.globalrequest',
         'zope.interface',
         ],
 


### PR DESCRIPTION
🚧 _bases on #44 ; rebase and change target branch when #44 is merged_

zope.globalrequest is not part of Plone and we should awoid to pull it in accidentally.