### PR TITLE
Plone 5.1.x support

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 parts +=

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -107,6 +107,7 @@ Changelog
 1.21.0 (2017-04-19)
 -------------------
 
+- Add Plone 5.1 support. [jone]
 - Make ``zope.globalrequest`` support optional. [jone]
 - Add testing layers for setting the default driver. [jone]
 - Add ``default_driver`` option to the driver. [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.26.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add Plone 5.1 support. [jone, maethu]
 
 
 1.26.2 (2017-08-14)
@@ -107,7 +107,6 @@ Changelog
 1.21.0 (2017-04-19)
 -------------------
 
-- Add Plone 5.1 support. [jone]
 - Make ``zope.globalrequest`` support optional. [jone]
 - Add testing layers for setting the default driver. [jone]
 - Add ``default_driver`` option to the driver. [jone]

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -8,6 +8,7 @@ from mechanize._form import MimeWriter
 from StringIO import StringIO
 import lxml.html.formfill
 import mimetypes
+import pkg_resources
 import shutil
 import urllib
 import urlparse
@@ -353,6 +354,13 @@ class Form(NodeWrapper):
                               'form-data; name="%s"' % fieldname, 1)
                 f = mw2.startbody(prefix=0)
                 f.write(value)
+
+        if pkg_resources.get_distribution('lxml').version >= '3.6.1':
+            # Since lxml 3.6.1 the lxml.html.form_values no longer include
+            # "file"-inputs, therefore we need to treat them as extra values.
+            for field in self.inputs:
+                if getattr(field, 'type', None) == 'file':
+                    field.write_mime_data(mw)
 
         mw.lastpart()
         value = data.getvalue()

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -375,12 +375,20 @@ class TextAreaField(NodeWrapper):
         if self.node.label is not None:
             return
 
-        if not self.attrib.get('id', None):
+        if self.attrib.get('id', None):
+            # Tinymce with dexterity has not the same label "for" as ids
+            # on the textarea.
+            for_attribute = self.attrib['id'].replace('.', '-')
+
+        elif self.attrib.get('name', None):
+            # TinyCME in Plone 5 has a even wronger structure, the textarea has
+            # no id attr at all.
+            for_attribute = self.attrib['name'].replace('.', '-')
+            self.attrib['id'] = for_attribute
+
+        else:
             return
 
-        # Tinymce with dexterity has not the same label "for" as ids
-        # on the textarea.
-        for_attribute = self.attrib['id'].replace('.', '-')
         label = self.body.xpath('//label[@for="%s"]' % for_attribute)
         if len(label) > 0:
             self.node.label = label.first.node

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -61,6 +61,11 @@ class Form(NodeWrapper):
                          normalize_spaces(input.label.raw_text)):
                 return input
 
+            checkbox_labels = (input.label is not None and
+                               input.label.css('>span.label'))
+            if checkbox_labels and label == checkbox_labels.first.text:
+                return input
+
         return self.find_widget(label_or_name)
 
     @wrapped_nodes
@@ -266,6 +271,11 @@ class Form(NodeWrapper):
                 labels.append(label)
             elif input.name:
                 labels.append(input.name)
+
+            checkbox_labels = (input.label is not None and
+                               input.label.css('>span.label'))
+            if checkbox_labels:
+                labels.append(checkbox_labels.first.text)
 
         return labels
 

--- a/ftw/testbrowser/pages/factoriesmenu.py
+++ b/ftw/testbrowser/pages/factoriesmenu.py
@@ -33,7 +33,9 @@ def add(type_name, browser=default_browser):
         raise ValueError('Cannot add "%s": no factories menu visible.' % (
                 type_name))
 
-    links = menu(browser=browser).css('.actionMenuContent').find(type_name)
+    # Plone 4: .actionMenuContent
+    # Plone 5: >ul
+    links = menu(browser=browser).css('.actionMenuContent, >ul').find(type_name)
     if len(links) == 0:
         raise ValueError('The type "%s" is not addable. Addable types: %s' % (
                 type_name,

--- a/ftw/testbrowser/pages/factoriesmenu.py
+++ b/ftw/testbrowser/pages/factoriesmenu.py
@@ -52,4 +52,6 @@ def addable_types(browser=default_browser):
     if not visible(browser=browser):
         raise ValueError('Factories menu is not visible.')
 
-    return menu(browser=browser).css('.actionMenuContent a').text
+    # Plone 4: .actionMenuContent
+    # Plone 5: >ul
+    return menu(browser=browser).css('.actionMenuContent, >ul').css('a').text

--- a/ftw/testbrowser/pages/folder_contents.py
+++ b/ftw/testbrowser/pages/folder_contents.py
@@ -1,8 +1,21 @@
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.nodes import wrap_nodes
+from ftw.testbrowser.tests import IS_PLONE_4
 from operator import itemgetter
 
 
+def only_plone_4(func):
+    def wrapper(*args, **kwargs):
+        if IS_PLONE_4:
+            return func(*args, **kwargs)
+        else:
+            raise NotImplementedError('The folder_contents page object '
+                                      'is not implemented for plone 5 so'
+                                      'far, since js is not yet supported.')
+    return wrapper
+
+
+@only_plone_4
 def titles(browser=default_browser):
     """Returns all titles of the objects listed on the folder contents view.
 
@@ -13,6 +26,7 @@ def titles(browser=default_browser):
     return title_cells(browser=browser).text
 
 
+@only_plone_4
 def title_cells(browser=default_browser):
     """Returns all the cell of the title column.
 
@@ -25,6 +39,7 @@ def title_cells(browser=default_browser):
     return wrap_nodes(cells, browser=browser)
 
 
+@only_plone_4
 def dicts(browser=default_browser, **kwargs):
     """Returns the folder contents table rows as dicts, as described
     in :py:func:`ftw.testbrowser.table.Table.dicts`.
@@ -37,6 +52,7 @@ def dicts(browser=default_browser, **kwargs):
     return table(browser=browser).dicts(head_offset=1, **kwargs)
 
 
+@only_plone_4
 def select(*objects):
     """Selects the checkboxes on one or more rows by objects.
 
@@ -45,6 +61,7 @@ def select(*objects):
     select_rows(map(row_by_object, objects))
 
 
+@only_plone_4
 def select_by_title(*titles):
     """Selects the checkboxes on one or more rows by the title of
     the objects.
@@ -55,6 +72,7 @@ def select_by_title(*titles):
     select_rows(map(row_by_title, titles))
 
 
+@only_plone_4
 def select_by_path(*paths):
     """Selects the checkboxes on one or more rows by the path of
     the objects.
@@ -65,6 +83,7 @@ def select_by_path(*paths):
     select_rows(map(row_by_path, paths))
 
 
+@only_plone_4
 def select_rows(rows):
     """Select the checkboxes of set of rows.
 
@@ -76,6 +95,7 @@ def select_rows(rows):
         checkbox.set('checked', '')
 
 
+@only_plone_4
 def row_by_title(title, browser=default_browser):
     """Returns the row for an object by its title.
 
@@ -101,6 +121,7 @@ def row_by_title(title, browser=default_browser):
                 title, urls))
 
 
+@only_plone_4
 def row_by_object(obj, browser=default_browser):
     """Returns the row for an object.
 
@@ -113,6 +134,7 @@ def row_by_object(obj, browser=default_browser):
     return row_by_path(path, browser=browser)
 
 
+@only_plone_4
 def row_by_path(path, browser=default_browser):
     """Returns the row for an object by its path.
 
@@ -132,6 +154,7 @@ def row_by_path(path, browser=default_browser):
                 path, rows.keys()))
 
 
+@only_plone_4
 def table(browser=default_browser):
     """The folder contents table node.
 
@@ -143,6 +166,7 @@ def table(browser=default_browser):
     return browser.css(selector).first
 
 
+@only_plone_4
 def form(browser=default_browser):
     """The folder contents form node.
 
@@ -153,6 +177,7 @@ def form(browser=default_browser):
     return browser.css('form[name=folderContentsForm]').first
 
 
+@only_plone_4
 def selected_paths(browser=default_browser):
     """Returns the paths of checkboxes currently selected.
 
@@ -163,6 +188,7 @@ def selected_paths(browser=default_browser):
     return tuple(form(browser=browser).values['paths:list'])
 
 
+@only_plone_4
 def rows_by_path(browser=default_browser):
     result = {}
     for row in table(browser=browser).body_rows:
@@ -171,6 +197,7 @@ def rows_by_path(browser=default_browser):
     return result
 
 
+@only_plone_4
 def column_title_by_name(name, browser=default_browser):
     mapping = dict(map(lambda th: (th.attrib.get('id'), th.text),
                        table(browser=browser).head_rows.css('th.column')))

--- a/ftw/testbrowser/pages/plone.py
+++ b/ftw/testbrowser/pages/plone.py
@@ -7,7 +7,9 @@ def logged_in(browser=default_browser):
     resturns the user-ID, otherwise ``False``.
     """
 
-    match = browser.css('#user-name')
+    # Plone 4: #user-name
+    # Plone 5: .plone-toolbar-submenu-header
+    match = browser.css('.plone-toolbar-submenu-header, #user-name')
     if match:
         return match[0].text.strip()
     else:

--- a/ftw/testbrowser/pages/plone.py
+++ b/ftw/testbrowser/pages/plone.py
@@ -8,8 +8,10 @@ def logged_in(browser=default_browser):
     """
 
     # Plone 4: #user-name
-    # Plone 5: .plone-toolbar-submenu-header
-    match = browser.css('.plone-toolbar-submenu-header, #user-name')
+    # Plone 5: #portal-personaltools .plone-toolbar-submenu-header
+    match = browser.css(
+        '#portal-personaltools .plone-toolbar-submenu-header,'
+        ' #user-name')
     if match:
         return match[0].text.strip()
     else:

--- a/ftw/testbrowser/pages/statusmessages.py
+++ b/ftw/testbrowser/pages/statusmessages.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.utils import normalize_spaces
+import re
 
 
 def messages(browser=default_browser):
@@ -18,7 +19,22 @@ def messages(browser=default_browser):
             continue
 
         key = tuple(type_classes)[0]
-        text = normalize_spaces(' '.join(message.css('dd').text_content()))
+
+        if message.css('dd'):
+            # Plone 4: <dl class="portalMessage info">
+            #              <dt>Info</dt>
+            #              <dd>Message</dd>
+            #          </dl>
+            text = normalize_spaces(' '.join(message.css('dd').text_content()))
+
+        elif message.css('strong'):
+            # Plone 5: <div class="portalMessage info">
+            #              <strong>Info</strong>
+            #              Message
+            #          </div>
+            type_text = message.css('strong').first.text
+            text = re.sub(r'^{} *'.format(re.escape(type_text)), '', message.text)
+
         if not text:
             # message is empty - skip it
             continue

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -4,7 +4,11 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
+import pkg_resources
 import transaction
+
+
+IS_PLONE_4 = pkg_resources.get_distribution('Plone').version[:2] == '4.'
 
 
 class BrowserTestCase(TestCase):

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -296,16 +296,16 @@ class TestBrowserCore(BrowserTestCase):
         browser.open(view='login_form').fill(
             {'Login Name': TEST_USER_NAME,
              'Password': TEST_USER_PASSWORD}).submit()
-        self.assertTrue(browser.css('#user-name'))
+        self.assertTrue(plone.logged_in())
 
         with browser.clone() as subbrowser:
             subbrowser.open()
-            self.assertTrue(subbrowser.css('#user-name'))
+            self.assertTrue(plone.logged_in(subbrowser))
             subbrowser.find('Log out').click()
-            self.assertFalse(subbrowser.css('#user-name'))
+            self.assertFalse(plone.logged_in(subbrowser))
 
         browser.reload()
-        self.assertTrue(browser.css('#user-name'))
+        self.assertTrue(plone.logged_in())
 
     @browsing
     def test_cloning_a_browser_copies_headers(self, browser):

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -8,6 +8,7 @@ from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import capture_streams
 from ftw.testbrowser.tests.helpers import register_view
@@ -264,7 +265,11 @@ class TestBrowserCore(BrowserTestCase):
         folder_contents_url = portal_url + 'folder_contents'
 
         browser.login(SITE_OWNER_NAME).open(folder_contents_url)
-        self.assertEquals(portal_url, browser.base_url)
+        if IS_PLONE_4:
+            self.assertEquals(portal_url, browser.base_url)
+        else:
+            self.assertEquals(folder_contents_url, browser.base_url)
+
         self.assertEquals(folder_contents_url, browser.url)
 
     @browsing

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -58,7 +58,7 @@ class TestBrowserContext(BrowserTestCase):
         with self.assertRaises(ContextNotFound) as cm:
             browser.context
 
-        self.assertEquals('No <base> tag found on current page.',
+        self.assertEquals('No <base> tag and no <body data-base-url> found.',
                           str(cm.exception))
 
     @browsing

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -3,9 +3,10 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
-from plone.app.testing import SITE_OWNER_NAME
+from unittest import skipUnless
 
 
 @all_drivers
@@ -77,6 +78,7 @@ class TestDexterityForms(BrowserTestCase):
         self.sync_transaction()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
+    @skipUnless(IS_PLONE_4, 'Relation fields in Plone5 does not have radio buttons')
     @browsing
     def test_radio_button_values_are_preserved(self, browser):
         self.grant('Manager')

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -14,7 +14,7 @@ class TestDexterityForms(BrowserTestCase):
     @browsing
     def test_tinymce_formfill(self, browser):
         self.grant('Manager')
-        browser.login(SITE_OWNER_NAME).open()
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page',
                       'Text': '<p>The body text.</p>'}).find('Save').click()
@@ -23,7 +23,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_save_add_form(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page'}).save()
         statusmessages.assert_no_error_messages()
@@ -33,7 +34,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_fill_umlauts(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': u'F\xf6lder'}).save()
         statusmessages.assert_no_error_messages()
@@ -41,7 +43,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_changing_checkbox_values(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': u'Page',
                       'Exclude from navigation': True}).save()
@@ -58,7 +61,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_checkbox_values_are_preserved(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
 
         browser.fill({'Title': u'Page',
@@ -75,7 +79,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_radio_button_values_are_preserved(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': u'Page used as relation'}).save()
         statusmessages.assert_no_error_messages()

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -3,10 +3,8 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import BrowserTestCase
-from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
-from unittest import skipUnless
 
 
 @all_drivers
@@ -78,9 +76,10 @@ class TestDexterityForms(BrowserTestCase):
         self.sync_transaction()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
-    @skipUnless(IS_PLONE_4, 'Relation fields in Plone5 does not have radio buttons')
     @browsing
-    def test_radio_button_values_are_preserved(self, browser):
+    def test_relation_list_and_relation_choice_autocomplete_widgets(self, browser):
+        # Plone 4: AutocompleteWidget from plone.formwidget.contenttree
+        # Plone 5: Patternslib based Autocompletewidget
         self.grant('Manager')
         browser.login().open()
         factoriesmenu.add('Page')

--- a/ftw/testbrowser/tests/test_headers.py
+++ b/ftw/testbrowser/tests/test_headers.py
@@ -11,7 +11,9 @@ class TestMechanizeHeaders(BrowserTestCase):
     @browsing
     def test_headers(self, browser):
         browser.open()
-        self.assertIn(browser.headers.get('content-type'),
+        # Plone 4: utf-8
+        # Plone 5: UTF-8
+        self.assertIn(browser.headers.get('content-type').lower(),
                       ('text/html; charset=utf-8',
                        'text/html;charset=utf-8'))
 
@@ -21,5 +23,8 @@ class TestMechanizeHeaders(BrowserTestCase):
     @browsing
     def test_webdav_headers(self, browser):
         browser.webdav('get')
-        self.assertEquals('text/html;charset=utf-8',
-                          browser.headers.get('content-type'))
+        # Plone 4: text/html; charset=utf-8
+        # Plone 5: text/html;charset=UTF-8
+        self.assertEquals(
+            'text/html;charset=utf-8',
+            browser.headers.get('content-type').lower().replace(' ', ''))

--- a/ftw/testbrowser/tests/test_nodes.py
+++ b/ftw/testbrowser/tests/test_nodes.py
@@ -131,10 +131,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.css('div.missing').first
 
-        self.assertEquals(
-            'Empty result set: <NodeWrapper:div, id="content">.css(\'div.missing\')'
-            ' did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <NodeWrapper:div, id="content">'
+                '.css(\'div.missing\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <NodeWrapper:article, id="content">'
+                '.css(\'div.missing\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_NoElementFound__with_xpath_on_node(self, browser):
@@ -143,10 +149,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.xpath('//table').first
 
-        self.assertEquals(
-            'Empty result set: <NodeWrapper:div, id="content">.xpath(\'//table\')'
-            ' did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <NodeWrapper:div, id="content">'
+                '.xpath(\'//table\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <NodeWrapper:article, id="content">'
+                '.xpath(\'//table\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_NoElementFound__with_css_on_result_set(self, browser):
@@ -155,10 +167,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.css('div.missing').first
 
-        self.assertEquals(
-            'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
-            '.css(\'div.missing\') did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
+                '.css(\'div.missing\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <Nodes: [<NodeWrapper:article, id="content">]>'
+                '.css(\'div.missing\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_NoElementFound__with_xpath_on_result_set(self, browser):
@@ -167,10 +185,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.xpath('//table').first
 
-        self.assertEquals(
-            'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
-            '.xpath(\'//table\') did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
+                '.xpath(\'//table\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <Nodes: [<NodeWrapper:article, id="content">]>'
+                '.xpath(\'//table\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_or_none_is_first_node(self, browser):

--- a/ftw/testbrowser/tests/test_pages_folder_contents.py
+++ b/ftw/testbrowser/tests/test_pages_folder_contents.py
@@ -4,9 +4,23 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import folder_contents
 from ftw.testbrowser.table import TableRow
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from unittest import skipIf
+from unittest import skipUnless
 
 
+@skipIf(IS_PLONE_4, 'folder_contents in plone 5 is js only.')
+@all_drivers
+class TestFolderContentsIsNotImplemented(BrowserTestCase):
+
+    def test_import_raises_notimplementederror(self):
+        with self.assertRaises(NotImplementedError):
+            from ftw.testbrowser.pages.folder_contents import titles
+            titles()
+
+
+@skipUnless(IS_PLONE_4, 'folder_contents in plone 5 is js only.')
 @all_drivers
 class TestFolderContents(BrowserTestCase):
 

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -326,7 +326,9 @@ class TestBrowserRequests(BrowserTestCase):
     @browsing
     def test_response_contenttype(self, browser):
         browser.open()
-        self.assertIn(browser.contenttype,
+        # Plone 4: utf-8
+        # Plone 5 UTF-8
+        self.assertIn(browser.contenttype.lower(),
                       ('text/html;charset=utf-8',
                        'text/html; charset=utf-8'))
 
@@ -344,7 +346,9 @@ class TestBrowserRequests(BrowserTestCase):
     @browsing
     def test_response_encoding(self, browser):
         browser.open()
-        self.assertEquals('utf-8', browser.encoding)
+        # Plone 4: utf-8
+        # Plone 5 UTF-8
+        self.assertEquals('utf-8', browser.encoding.lower())
 
         browser.open(self.json_view_url, data={'foo': 'bar'})
         self.assertEquals(None, browser.encoding)

--- a/ftw/testbrowser/tests/test_widgets_datetime.py
+++ b/ftw/testbrowser/tests/test_widgets_datetime.py
@@ -4,10 +4,20 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+import transaction
 
 
 @all_drivers
 class TestDatetimeWidget(BrowserTestCase):
+
+    def setUp(self):
+        super(TestDatetimeWidget, self).setUp()
+        registry = getUtility(IRegistry)
+        if 'plone.portal_timezone' in registry:
+            registry['plone.portal_timezone'] = 'Europe/Berlin'
+            transaction.commit()
 
     @browsing
     def test_z3cform_formfill(self, browser):

--- a/ftw/testbrowser/tests/views/z3cform.py
+++ b/ftw/testbrowser/tests/views/z3cform.py
@@ -1,4 +1,5 @@
-from collective.z3cform.datagridfield import DictRow, DataGridFieldFactory
+from collective.z3cform.datagridfield import DataGridFieldFactory
+from collective.z3cform.datagridfield import DictRow
 from datetime import date
 from datetime import datetime
 from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
@@ -6,6 +7,7 @@ from plone.formwidget.contenttree import MultiContentTreeFieldWidget
 from plone.formwidget.contenttree import PathSourceBinder
 from plone.formwidget.contenttree import UUIDSourceBinder
 from plone.i18n.normalizer import idnormalizer
+from plone.uuid.interfaces import IUUID
 from plone.z3cform.layout import FormWrapper
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.browser.radio import RadioFieldWidget
@@ -156,6 +158,7 @@ class ShoppingForm(Form):
             if isinstance(value, (datetime, date)):
                 value = value.isoformat()
 
+            value = IUUID(value, value)
             self.result_data[key] = value
 
 

--- a/ftw/testbrowser/tests/views/z3cform.py
+++ b/ftw/testbrowser/tests/views/z3cform.py
@@ -2,6 +2,7 @@ from collective.z3cform.datagridfield import DataGridFieldFactory
 from collective.z3cform.datagridfield import DictRow
 from datetime import date
 from datetime import datetime
+from OFS.interfaces import IItem
 from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
 from plone.formwidget.contenttree import MultiContentTreeFieldWidget
 from plone.formwidget.contenttree import PathSourceBinder
@@ -154,11 +155,6 @@ class ShoppingForm(Form):
         for key, value in data.items():
             if not value:
                 continue
-
-            if isinstance(value, (datetime, date)):
-                value = value.isoformat()
-
-            value = IUUID(value, value)
             self.result_data[key] = value
 
 
@@ -169,6 +165,23 @@ class ShoppingView(FormWrapper):
     def render(self):
         if self.form_instance.result_data:
             self.request.RESPONSE.setHeader('Content-Type', 'application/json')
-            return json.dumps(self.form_instance.result_data)
+            return json.dumps(self.make_json_serializable(
+                self.form_instance.result_data))
         else:
             return super(ShoppingView, self).render()
+
+    def make_json_serializable(self, value):
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+
+        if IItem.providedBy(value):
+            return IUUID(value)
+
+        if isinstance(value, (list, tuple)):
+            return map(self.make_json_serializable, value)
+
+        if isinstance(value, dict):
+            return dict(zip(*map(self.make_json_serializable,
+                                 zip(*value.items()))))
+
+        return value

--- a/ftw/testbrowser/widgets/autocomplete.py
+++ b/ftw/testbrowser/widgets/autocomplete.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 from lxml import etree
+from plone.uuid.interfaces import IUUID
 import re
 
 
@@ -88,6 +89,38 @@ class AutocompleteWidget(PloneWidget):
         for value in values:
             if hasattr(value, 'getPhysicalPath'):
                 new_values.append('/'.join(value.getPhysicalPath()))
+            else:
+                new_values.append(value)
+        return new_values
+
+
+@widget
+class PatternsLibAutocompleteWidget(PloneWidget):
+    """Represents the Autocomplete widget implemented with patternslib"""
+
+    @staticmethod
+    def match(node):
+        if not PloneWidget.match(node):
+            return False
+
+        return len(node.css('[data-pat-relateditems]')) > 0
+
+    def fill(self, values):
+        """With patternslib the Relation fields are represented as
+        input text field containing one uid, or multiple uids seperated
+        by a colon.
+        """
+        if not isinstance(values, (list, set, tuple)):
+            values = [values]
+
+        values = self._resolve_objects_to_uid(values)
+        self.css('input').first.value = ':'.join(values)
+
+    def _resolve_objects_to_uid(self, values):
+        new_values = []
+        for value in values:
+            if hasattr(value, 'getPhysicalPath'):
+                new_values.append(IUUID(value))
             else:
                 new_values.append(value)
         return new_values

--- a/ftw/testbrowser/widgets/datagridwidget.py
+++ b/ftw/testbrowser/widgets/datagridwidget.py
@@ -4,6 +4,7 @@ from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 from ftw.testbrowser.widgets.base import WIDGETS
 from lxml.html import formfill
+from plone.uuid.interfaces import IUUID
 
 
 @widget
@@ -73,6 +74,7 @@ class DataGridWidget(PloneWidget):
                 return
 
         handlers = (
+            ('input[data-pat-relateditems]', self._fill_patternslib_relatedItems),
             ('input[type=text]', self._fill_text),
             ('select', self._fill_select),
             ('input[type=checkbox]', self._fill_checkbox),
@@ -98,3 +100,9 @@ class DataGridWidget(PloneWidget):
         else:
             value = ''
         return formfill._fill_multiple(node, value)
+
+    def _fill_patternslib_relatedItems(self, node, values):
+        if not isinstance(values, (list, set, tuple)):
+            values = [values]
+        values = map(IUUID, values)
+        node.value = ':'.join(values)

--- a/ftw/testbrowser/widgets/datetime.py
+++ b/ftw/testbrowser/widgets/datetime.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
+import json
 
 
 @widget
@@ -50,3 +51,27 @@ class DateTimeWidget(PloneWidget):
             return None
         else:
             return self.css(xpr).first
+
+
+@widget
+class PaternslibDateTimeWidget(PloneWidget):
+    """Represents the z3cform paternslib datetime widget.
+    """
+
+    field_selector = '>input[data-pat-pickadate]'
+
+    @staticmethod
+    def match(node):
+        if not PloneWidget.match(node):
+            return False
+
+        return len(node.css(PaternslibDateTimeWidget.field_selector)) == 1
+
+    def fill(self, value):
+        field = self.css(PaternslibDateTimeWidget.field_selector).first
+        config = json.loads(field.attrib['data-pat-pickadate'])
+
+        if config.get('time'):
+            field.set('value', value.strftime('%Y-%m-%d %H:%M'))
+        else:
+            field.set('value', value.strftime('%Y-%m-%d'))

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,11 @@ version = '1.26.3.dev0'
 
 
 tests_require = [
+    'Plone',
+    'Products.CMFCore',
+    'Products.CMFPlone',
+    'Products.GenericSetup',
+    'Products.statusmessages',
     'collective.z3cform.datagridfield',
     'ftw.builder',
     'ftw.testing',
@@ -18,10 +23,6 @@ tests_require = [
     'plone.formwidget.contenttree',
     'plone.i18n',
     'plone.z3cform',
-    'Products.CMFCore',
-    'Products.CMFPlone',
-    'Products.GenericSetup',
-    'Products.statusmessages',
     'transaction',
     'unittest2',
     'z3c.form',

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+
+package-name = ftw.testbrowser
+


### PR DESCRIPTION
Add support for Plone 5.1.

Changes needed:
- There is no `<base>`-tag anymore.
- lxml has changed regarding file uploads.
- Factories menu markup has changed.
- Folder-Contents was reimplemented with JavaScript, the page object is therefore obsolete.
- The user menu markup has changed.
- The status messages markup has changed.
- Various minor changes.
- New autocomplete widget.