### PR TITLE
Improve tooling and defaults regarding exception handling

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.21.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Introduce ``browser.status_reason``. [jone]
+- Introduce ``browser.status_code``. [jone]
 
 
 1.21.0 (2017-04-19)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 1.21.1 (unreleased)
 -------------------
 
+- Forbid setting of "x-zope-handle-errors" header. [jone]
+- Add an option ``browser.exception_bubbling``, disabled by default. [jone]
+- Mechanize: no longer disable "x-zope-handle-errors". [jone]
+- Introduce ``browser.expect_http_error()`` context manager. [jone]
+- Add an option ``browser.raise_http_errors``, enabled by default. [jone]
+- Raise ``HTTPClientError`` and ``HTTPServerError`` by default. [jone]
 - Introduce ``browser.status_reason``. [jone]
 - Introduce ``browser.status_code``. [jone]
 

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -518,3 +518,69 @@ Then use the ``webdav`` method for making requests in the test:
             self.assertEquals('1,2', browser.response.headers.get('DAV'))
 
 .. seealso:: :py:func:`ftw.testbrowser.core.Browser.webdav`
+
+
+Error handling
+==============
+
+The testbrowser raises exceptions by default when a request was not successful.
+When the response has a status code of `4xx`, a
+:py:class:`ftw.testbrowser.exceptions.HTTPClientError` is raised,
+when the status code is `5xx`, a
+:py:class:`ftw.testbrowser.exceptions.HTTPServerError` is raised.
+
+
+Disabling HTTP exceptions
+-------------------------
+
+Disable the ``raise_http_errors`` flag when the test browser should not raise
+any HTTP exceptions:
+
+.. code::
+
+   @browsing
+   def test(self, browser):
+       browser.raise_http_errors = False
+       browser.open(view='not-existing')
+
+
+Expecting HTTP exceptions
+-------------------------
+
+Sometimes we want to make sure that the server responds with a certain bad
+status. For making that easy, the testbrowser provides assertion context
+managers:
+
+
+.. code::
+
+   @browsing
+   def test(self, browser):
+       with browser.expect_http_error():
+           browser.open(view='failing')
+
+       with browser.expect_http_error(status_code=404):
+           browser.open(view='not-existing')
+
+       with browser.expect_http_error(status_reason='Bad Request'):
+           browser.open(view='get-record-by-id')
+
+
+Exception bubbling
+------------------
+
+Exceptions happening in views can not be catched in the browser by default.
+When using an internally dispatched driver such as Mechanize,
+the option ``exception_bubbling`` makes the Zope Publisher and Mechanize
+let the exceptions bubble up into the test method, so that it can be catched
+and asserted there.
+
+.. code::
+
+   @browsing
+   def test(self, browser):
+       browser.exception_bubbling = True
+       with self.assertRaises(ValueError) as cm:
+           browser.open(view='failing')
+
+       self.assertEquals('No valid value was submitted', str(cm.exception))

--- a/ftw/testbrowser/__init__.py
+++ b/ftw/testbrowser/__init__.py
@@ -2,6 +2,11 @@ from ftw.testbrowser.core import Browser
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.drivers.layers import DefaultDriverFixture
+from ftw.testbrowser.exceptions import HTTPClientError
+from ftw.testbrowser.exceptions import HTTPServerError
+
+
+HTTPClientError, HTTPServerError  # noqa
 
 
 #: The singleton browser instance acting as default browser.

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from copy import deepcopy
 from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
 from ftw.testbrowser.drivers.requestsdriver import RequestsDriver
@@ -7,6 +8,9 @@ from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.exceptions import ContextNotFound
 from ftw.testbrowser.exceptions import FormFieldNotFound
+from ftw.testbrowser.exceptions import HTTPClientError
+from ftw.testbrowser.exceptions import HTTPError
+from ftw.testbrowser.exceptions import HTTPServerError
 from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.interfaces import IBrowser
 from ftw.testbrowser.nodes import wrap_nodes
@@ -80,6 +84,15 @@ class Browser(object):
     decorator uses the global (singleton) browser and sets it up / tears it
     down using the context manager syntax. See the
     `ftw.testbrowser.browsing`_ documentation for more information.
+
+    :ivar raise_http_errors: HTTPError exceptions are raised on 4xx
+      and 5xx response codes when enabled (Default: ``True``).
+    :type raise_http_errors: ``bool``
+
+    :ivar exception_bubbling: When enabled, exceptions from within the Zope
+      view are bubbled up into the test method if the driver supports it.
+      (Default: ``False``).
+    :type exception_bubbling: ``bool``
     """
 
     implements(IBrowser)
@@ -105,6 +118,8 @@ class Browser(object):
         state.
         """
         self.request_library = None
+        self.raise_http_errors = True
+        self.exception_bubbling = False
         self.next_app = None
         self.app = None
         self.document = None
@@ -223,7 +238,17 @@ class Browser(object):
             referer_url=referer_url,
             headers=headers)
         self.parse(body)
+        self.raise_for_status()
         return self
+
+    def raise_for_status(self):
+        if not self.raise_http_errors:
+            return
+
+        if 400 <= self.status_code < 500:
+            raise HTTPClientError(self.status_code, self.status_reason)
+        elif 500 <= self.status_code < 600:
+            raise HTTPServerError(self.status_code, self.status_reason)
 
     def on(self, url_or_object=None, data=None, view=None, library=None):
         """``on`` does almost the same thing as ``open``. The difference is that
@@ -300,8 +325,10 @@ class Browser(object):
         :rtype: :py:class:`ftw.testbrowser.core.Browser`
         """
         self._verify_setup()
-        self._status_code, self._status_reason, body = self.get_driver().reload()
+        driver = self.get_driver()
+        self._status_code, self._status_reason, body = driver.reload()
         self.parse(body)
+        self.raise_for_status()
         return self
 
     @property
@@ -390,6 +417,13 @@ class Browser(object):
         .. seealso:: :py:func:`clear_request_header`
         """
 
+        if name.lower() == 'x-zope-handle-errors':
+            raise ValueError(
+                'The testbrowser does no longer allow to set the request'
+                ' header \'X-zope-handle-errros\'; use the'
+                ' exception_bubbling flag instead.'
+            )
+
         self.session_headers.append((name, value))
         for driver in self.drivers.values():
             driver.append_request_header(name, value)
@@ -418,6 +452,13 @@ class Browser(object):
         :param name: Name of the request header as positional arguments
         :type name: string
         """
+
+        if name.lower() == 'x-zope-handle-errors':
+            raise ValueError(
+                'The testbrowser does no longer allow to set the request'
+                ' header \'X-zope-handle-errros\'; use the'
+                ' exception_bubbling flag instead.'
+            )
 
         for header_name, value in self.session_headers[:]:
             if header_name == name:
@@ -780,6 +821,36 @@ class Browser(object):
         else:
             return self._load_html(xml_or_html,
                                    parse_html)
+
+    @contextmanager
+    def expect_http_error(self, code=None, reason=None):
+        """Context manager for expecting certain HTTP errors.
+        The ``code`` and ``reason`` arguments may be provided or omitted.
+        The values are only asserted if the arguments are provided.
+        An assertion error is raised when the HTTP error is not cathed in the
+        code block.
+        The code block may make a request or reload the browser.
+
+        :param code: The status code to assert.
+        :type code: ``int``
+        :param reason: The status reason to assert.
+        :type reason: ``string``
+        :raises: :py:exc:`AssertionError`
+        """
+
+        try:
+            yield
+        except HTTPError, exc:
+            if code is not None and code != exc.status_code:
+                raise AssertionError(
+                    'Expected HTTP error with status code {}, got {}.'.format(
+                        code, exc.status_code))
+            if reason is not None and reason != exc.status_reason:
+                raise AssertionError(
+                    'Expected HTTP error with status {!r}, got {!r}.'.format(
+                        reason, exc.status_reason))
+        else:
+            raise AssertionError('Expected a HTTP error but it didn\'t occur.')
 
     def clone(self):
         """Creates a new browser instance with a cloned state of the

--- a/ftw/testbrowser/drivers/mechdriver.py
+++ b/ftw/testbrowser/drivers/mechdriver.py
@@ -57,7 +57,8 @@ class MechanizeDriver(object):
         except:
             self.response = None
             raise
-        return self.response
+
+        return self.response.code, self.response.msg, self.response
 
     def reload(self):
         if self.previous_make_request is None:

--- a/ftw/testbrowser/drivers/mechdriver.py
+++ b/ftw/testbrowser/drivers/mechdriver.py
@@ -9,6 +9,7 @@ from requests.structures import CaseInsensitiveDict
 from zope.interface import implements
 import pkg_resources
 import urllib
+import urllib2
 
 
 try:
@@ -42,7 +43,6 @@ class MechanizeDriver(object):
     @isolated
     def make_request(self, method, url, data=None, headers=None,
                      referer_url=None):
-
         data = self._prepare_post_data(data)
         request = Request(url, data)
         if referer_url:
@@ -50,10 +50,16 @@ class MechanizeDriver(object):
                                          {'REFERER': referer_url,
                                           'HTTP_REFERER': referer_url})
 
+        if self.browser.exception_bubbling:
+            self._add_headers_to_request(
+                request, {'X-zope-handle-errors': 'False'})
+
         self._add_headers_to_request(request, headers)
 
         try:
             self.response = self._get_mechbrowser().open(request)
+        except urllib2.HTTPError as response:
+            self.response = response
         except:
             self.response = None
             raise
@@ -122,8 +128,6 @@ class MechanizeDriver(object):
 
         if self.mechbrowser is None:
             self.mechbrowser = Zope2MechanizeBrowser(self.browser.app)
-            self._get_mechbrowser().addheaders.append((
-                'X-zope-handle-errors', 'False'))
         return self.mechbrowser
 
     def _prepare_post_data(self, data):

--- a/ftw/testbrowser/drivers/requestsdriver.py
+++ b/ftw/testbrowser/drivers/requestsdriver.py
@@ -34,6 +34,10 @@ class RequestsDriver(object):
         if urlparse.urlparse(url).hostname == 'nohost':
             raise ZServerRequired()
 
+        if self.browser.exception_bubbling:
+            raise ValueError('The requests driver does not support'
+                             ' exception bubbling.')
+
         if headers is None:
             headers = {}
 

--- a/ftw/testbrowser/drivers/requestsdriver.py
+++ b/ftw/testbrowser/drivers/requestsdriver.py
@@ -42,13 +42,12 @@ class RequestsDriver(object):
             headers['HTTP_REFERER'] = referer_url
 
         with verbose_logging():
-            try:
-                self.response = self.requests_session.request(
-                    method, url, data=data, headers=headers)
-            except:
-                self.response = None
+            self.response = self.requests_session.request(
+                method, url, data=data, headers=headers)
 
-        return StringIO(self.response.content)
+            return (self.response.status_code,
+                    self.response.reason,
+                    StringIO(self.response.content))
 
     def reload(self):
         if self.previous_make_request is None:

--- a/ftw/testbrowser/drivers/staticdriver.py
+++ b/ftw/testbrowser/drivers/staticdriver.py
@@ -31,7 +31,7 @@ class StaticDriver(object):
     def reload(self):
         if self.body is None:
             raise BlankPage('Cannot reload.')
-        return self.body
+        return 200, 'OK', self.body
 
     def get_response_body(self):
         if self.body is None:

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -92,3 +92,37 @@ class ContextNotFound(BrowserException):
         if message is None:
             message = re.sub(r'\s+', ' ', self.__doc__.strip())
         Exception.__init__(self, message)
+
+
+class HTTPError(IOError):
+    """The request has failed.
+
+    :ivar status_code: The status code number
+    :type status_code: ``int``
+    :ivar status_reasoon: The status reason.
+    :type status_reasoon: ``string``
+    """
+
+    def __init__(self, status_code, status_reason):
+        self.status_code = status_code
+        self.status_reason = status_reason
+
+
+class HTTPClientError(HTTPError):
+    """The request caused a client error with status codes 400-499.
+
+    :ivar status_code: The status code number, e.g. ``404``
+    :type status_code: ``int``
+    :ivar status_reasoon: The status reason, e.g. ``"Not Found"``
+    :type status_reasoon: ``string``
+    """
+
+
+class HTTPServerError(HTTPError):
+    """The request caused a server error with status codes 500-599.
+
+    :ivar status_code: The status code number, e.g. ``500``
+    :type status_code: ``int``
+    :ivar status_reasoon: The status reason, e.g. ``"Internal Server Error"``
+    :type status_reasoon: ``string``
+    """

--- a/ftw/testbrowser/interfaces.py
+++ b/ftw/testbrowser/interfaces.py
@@ -50,8 +50,8 @@ class IDriver(Interface):
         :type headers: dict
         :param referer_url: The referer URL or ``None``.
         :type referer: string or ``None``
-        :returns: Response body
-        :rtype: string
+        :returns: Status code, reason and body
+        :rtype: tuple: (int, string, string or stream)
         """
 
     def reload():
@@ -60,8 +60,8 @@ class IDriver(Interface):
         This applies for GET as well as POST requests.
 
         :raises: :py:exc:`ftw.testbrowser.exceptions.BlankPage`
-        :returns: Response body
-        :rtype: string
+        :returns: Status code, reason and body
+        :rtype: tuple: (int, string, string or stream)
         """
 
     def get_response_body():

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -100,6 +100,12 @@ class TestBrowserCore(FunctionalTestCase):
                                     'login_form')),
                           browser.url)
 
+    @browsing
+    def test_status_is_exposed(self, browser):
+        browser.open()
+        self.assertEquals(200, browser.status_code)
+        self.assertEquals('OK', browser.status_reason.upper())
+
     @skip_driver(LIB_REQUESTS, """
     The behavior in this situation is not consistent between mechanize
     and requests drivers.


### PR DESCRIPTION
When using Mechanize, exception in the application code used to bubbleup into the test by default.
But when using requests, this is not possible, resulting in HTTP errors. This behavior is inconsistent between drivers and it is not the same as what happens with real browsers. It is important though that the developer is notified of unexpected HTTP errors.

In order to clean up the inconsistencies and provide better tooling for working with exceptions various changes are made:

- Exceptions are no longer bubbling up by default in mechanize. The option ``browser.exception_bubbling = True`` enables the old behavior.
- The ``x-zope-handle-errors`` is now forbidden so that the testbrowser is in complete control of this behavior; use ``exception_bubbling`` instead.
- New exceptions ``HTTPClientError`` and ``HTTPServerError`` are added and are raised by all drivers by default.
- The option ``browser.raise_http_errors = False`` allows to disable the HTTP exceptions.
- With the new ``browser.expect_http_error`` context manager a simple tool for asserting HTTP errors is provided.
- A new property ``browser.status_code`` provides the last responses status code.
- A new property ``browser.status_reason`` provides the last responses reason.

Fixes #46