### PR TITLE
HTTPError: include code and reason in exception.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.22.2 (unreleased)
 -------------------
 
+- HTTPError: include code and reason in exception. [jone]
 - Docs: Fix wrong expect_http_error argument names. [jone]
 
 

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -106,6 +106,8 @@ class HTTPError(IOError):
     def __init__(self, status_code, status_reason):
         self.status_code = status_code
         self.status_reason = status_reason
+        super(HTTPError, self).__init__('{} {}'.format(
+            status_code, status_reason))
 
 
 class HTTPClientError(HTTPError):

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -115,6 +115,7 @@ class TestBrowserCore(FunctionalTestCase):
 
         self.assertEquals(404, cm.exception.status_code)
         self.assertEquals('Not Found', cm.exception.status_reason)
+        self.assertEquals('404 Not Found', str(cm.exception))
 
         with self.assertRaises(HTTPClientError):
             browser.reload()


### PR DESCRIPTION
Include error code and reason in the HTTPError exception message so that code and reason are printed when in the traceback.