### PR TITLE
Fix `browser.debug` when body is a bytestring.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix `browser.debug` when body is a bytestring. [jone]
 
 
 1.23.0 (2017-04-28)

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -920,10 +920,11 @@ class Browser(object):
             source = self.contents
             if isinstance(source, unicode):
                 source = source.encode('utf-8')
-                file_.write(source)
-                cmd = 'open {0}'.format(path)
-                print '> {0}'.format(cmd)
-                os.system(cmd)
+
+            file_.write(source)
+            cmd = 'open {0}'.format(path)
+            print '> {0}'.format(cmd)
+            os.system(cmd)
 
     def _verify_setup(self):
         if self.request_library is None:


### PR DESCRIPTION
``browser.debug`` broke because of a wrong identing, causing it to do nothing when the response body is a bytestring.