### PR TITLE
Add traversal driver.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add traversal request driver. [jone]
 
 
 1.23.2 (2017-06-16)

--- a/docs/source/api_browser.rst
+++ b/docs/source/api_browser.rst
@@ -39,6 +39,14 @@ MechanizeDriver
    :members:
 
 
+TraversalDriver
+---------------
+
+.. autoclass:: ftw.testbrowser.drivers.traversaldriver.TraversalDriver
+   :show-inheritance:
+   :members:
+
+
 StaticDriver
 ------------
 

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -60,6 +60,7 @@ automatic driver selection:
     from ftw.testbrowser.core import Browser
     from ftw.testbrowser.core import LIB_MECHANIZE
     from ftw.testbrowser.core import LIB_REQUESTS
+    from ftw.testbrowser.core import LIB_TRAVERSAL
 
     browser = Browser()
     # always use mechanize:
@@ -67,6 +68,9 @@ automatic driver selection:
 
     # or always use requests:
     browser.default_driver = LIB_REQUESTS
+
+    # or use traversal in the same transactions with same connection:
+    browser.default_driver = LIB_TRAVERSAL
 
 
 When using the testbrowser in a ``plone.testing`` layer, the driver can be
@@ -76,6 +80,7 @@ chosen by using a standard ``plone.testing`` fixture:
 
     from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
     from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
+    from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
     from plone.app.testing import PLONE_FIXTURE
     from plone.app.testing import FunctionalTesting
 
@@ -89,6 +94,11 @@ chosen by using a standard ``plone.testing`` fixture:
         bases=(PLONE_FIXTURE,
                REQUESTS_BROWSER_FIXTURE),
         name='functional:requests')
+
+    MY_FUNCTIONAL_TESTING_WITH_TRAVERSAL = FunctionalTesting(
+        bases=(PLONE_FIXTURE,
+               TRAVERSAL_BROWSER_FIXTURE),
+        name='functional:traversal')
 
 
 

--- a/ftw/testbrowser/__init__.py
+++ b/ftw/testbrowser/__init__.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser.core import Browser
+from ftw.testbrowser.core import LIB_TRAVERSAL
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.drivers.layers import DefaultDriverFixture
@@ -41,6 +42,9 @@ def browsing(func):
     test_function.__name__ = func.__name__
     return test_function
 
+
+#: A plone.testing layer which sets the default driver to Traversal.
+TRAVERSAL_BROWSER_FIXTURE = DefaultDriverFixture(LIB_TRAVERSAL)
 
 #: A plone.testing layer which sets the default driver to Mechanize.
 MECHANIZE_BROWSER_FIXTURE = DefaultDriverFixture(LIB_MECHANIZE)

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
 from ftw.testbrowser.drivers.requestsdriver import RequestsDriver
 from ftw.testbrowser.drivers.staticdriver import StaticDriver
+from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
 from ftw.testbrowser.exceptions import AmbiguousFormFields
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
@@ -45,6 +46,9 @@ else:
     from plone.app.testing import TEST_USER_PASSWORD
 
 
+#: Constant for choosing the mechanize library (interally dispatched requests)
+LIB_TRAVERSAL = TraversalDriver.LIBRARY_NAME
+
 #: Constant for choosing the requests library (actual requests)
 LIB_REQUESTS = RequestsDriver.LIBRARY_NAME
 
@@ -59,6 +63,7 @@ LIB_STATIC = StaticDriver.LIBRARY_NAME
 #: This design is historical so that the library constants
 #: keep working. This mapping may be monkey patched.
 DRIVER_FACTORIES = {
+    TraversalDriver.LIBRARY_NAME: TraversalDriver,
     MechanizeDriver.LIBRARY_NAME: MechanizeDriver,
     RequestsDriver.LIBRARY_NAME: RequestsDriver,
     StaticDriver.LIBRARY_NAME: StaticDriver}

--- a/ftw/testbrowser/drivers/traversaldriver.py
+++ b/ftw/testbrowser/drivers/traversaldriver.py
@@ -1,0 +1,390 @@
+"""
+TRAVERSAL DRIVER
+
+GOAL:
+The advantage of the traversal driver is that it executes requests within the
+same Zope transaction and ZODB connection as the test is executed.
+This makes it possible to no longer commit any transactions in tests, so that
+the testbrowser can be used with Plone's IntegrationTesting layer.
+
+BACKGROUND:
+In projects which also use SQL / SQLAlchemy, it is hard to provide a testing
+fixture with SQL data while still providing isolation between tests.
+The reason is that it is hard to rollback any number of transactions in SQL,
+as it is supported by the ZODB demo storage.
+By stopping to commit we can isolate by rolling back transaction savepoints.
+
+IMPLEMENTATION:
+The traversal driver works quite a lot like Mechanize is set up internally
+by plone.app.testing: it calls ``publish_module`` at the end.
+
+For the session handling (cookies, authorization headers) and the request
+preparation we use the ``requests`` module.
+"""
+
+
+from Acquisition import aq_base
+from ftw.testbrowser.drivers.utils import isolated
+from ftw.testbrowser.drivers.utils import remembering_for_reload
+from ftw.testbrowser.exceptions import BlankPage
+from ftw.testbrowser.exceptions import RedirectLoopException
+from ftw.testbrowser.interfaces import IDriver
+from ftw.testbrowser.utils import copy_docs_from_interface
+from requests.structures import CaseInsensitiveDict
+from StringIO import StringIO
+from urllib import unquote
+from urlparse import urlparse
+from zope.interface import implements
+from ZPublisher.BaseRequest import RequestContainer
+from ZPublisher.Iterators import IStreamIterator
+from ZPublisher.Response import Response
+from ZPublisher.Test import publish_module
+import httplib
+import requests
+import sys
+import Zope2
+import ZPublisher
+
+
+# from plone.testing._z2_testbrowser
+class TestResponse(Response):
+
+    def setBody(self, body, title='', is_error=0, **kw):
+        if IStreamIterator.providedBy(body):
+            body = ''.join(body)
+        Response.setBody(self, body, title, is_error, **kw)
+
+
+class NoCommitTransactionsManagerWrapper(object):
+    """
+    On startup, Zope creates a ``ZApplicationWrapper`` instance and stores it
+    as module global in the ``Zope2`` module.
+    Whenever a request is processed with ``publish_module``, the application
+    wrapper instance is injected as
+    ``request['PARENTS'] = [application_wrapper]``
+    and is therefore always bobo-traversed first when the traversal is started.
+    Whenever the application wrapper is bobo-traversed, it opens a ZODB
+    connection and gets the application root on this fresh connection.
+    In order to reuse the testing connection in the request we want to prevent
+    a ZODB connection to be opened.
+
+    In ``publish_module``, the only thing happening between setting the
+    application wrapper as ``PARENTS`` and traversing the path is that the
+    transactions manager's ``begin()`` method is called.
+    This is the reason we why we patch the transactions manager with this
+    NoCommitTransactionsManagerWrapper in order to replace the ``PARENTS`` list
+    to contain the actual application root so that no new ZODB connection is
+    opened.
+
+    Since the traversal driver should not reset or commit the transaction,
+    we intercept those intents in the ``NoCommitTransactionsManagerWrapper``.
+    Since we should only do that while processing a request, the wrapper is
+    context manager which delegates to the original transactions manager when
+    not active.
+    """
+
+    @classmethod
+    def setup(klass):
+        """Makes sure that the transactions manager is wrapped and the patch
+        is installed.
+        """
+        if not isinstance(Zope2.zpublisher_transactions_manager, klass):
+            # Patch the module global, from where ``get_module_info`` will
+            # get the transactions manager.
+            Zope2.zpublisher_transactions_manager = klass(
+                Zope2.zpublisher_transactions_manager)
+
+            # ``get_module_info`` caches the results in tis module cache.
+            # The cache may already contain the module infos of Zope2.
+            # By popping the caches of the Zope2 module it will be refeched
+            # from Zope2.zpublisher_transactions_manager on the next call.
+            modules_cache = ZPublisher.Publish.get_module_info.func_defaults[0]
+            assert isinstance(modules_cache, dict), \
+                'get_module_info modules cache changed unexpectedly.'
+            modules_cache.pop('Zope2', None)
+            modules_cache.pop('Zope2.cgi', None)
+
+        return Zope2.zpublisher_transactions_manager
+
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+        self.active = False
+        self.next_request = None
+        self.app = None
+
+    def __call__(self, next_request, app):
+        """Before the context manager is activated in the with-statement, it must
+        be called for configuration.
+
+        :param next_request: The request object which will be processed within
+          this context manager next.
+        :type next_request: :py:class:`ZPublisher.Request.Request`
+        :param app: A zope application object from the current connection.
+        :type app: Zope application object
+        :returns: self
+        :rtype: :py:class:`.NoCommitTransactionsManagerWrapper'
+        """
+        self.next_request = next_request
+        self.app = app
+        return self
+
+    def __enter__(self):
+        """While the context manager is active, all transaction interaction
+        intents (begin, commit, abort, recordMetaData) will be silently
+        ignored.
+        """
+        assert self.next_request is not None, (
+            '{!r} must be called before'' activated with'
+            ' "with"-statement'.format(self))
+        self.active = True
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.active = False
+        self.next_request = None
+        self.app = None
+
+    def begin(self):
+        if not self.active:
+            return self.wrapped.begin()
+        else:
+            self.replace_app_in_parents()
+
+    def commit(self):
+        if not self.active:
+            return self.wrapped.commit()
+
+    def abort(self):
+        if not self.active:
+            return self.wrapped.abort()
+
+    def recordMetaData(self, object, request):
+        if not self.active:
+            return self.wrapped.recordMetaData(object, request)
+
+    def replace_app_in_parents(self):
+        """When the ``ZApplicationWrapper`` is in the ``PARENTS`` list,
+        it will make a new DB connection when bobo-traversed, which will
+        not include the uncommitted state of the current transaction.
+        With the NoCommitTransactionsManagerWrapper we make sure that this
+        does not happen so that we have access to the uncommitted state in
+        the request.
+        """
+
+        self.next_request['PARENTS'][0] = self.app
+
+
+@copy_docs_from_interface
+class TraversalDriver(object):
+    """The traversal driver simulates requests by by calling
+    the zope traversal directly.
+    The purpose of the traversal driver is to be able to use a testbrowser
+    in the same transaction / connection as the test code is run.
+    This makes it possible to write browser tests without transactions.
+    """
+    implements(IDriver)
+
+    LIBRARY_NAME = 'traversal library'
+
+    def __init__(self, browser):
+        self.browser = browser
+        self.reset()
+        self.transactions_manager = NoCommitTransactionsManagerWrapper.setup()
+
+    def reset(self):
+        self.response = None
+        self.current_url = None
+        self.previous_make_request = None
+        self.requests_session = requests.Session()
+        self.append_request_header('X-zope-handle-errors', 'False')
+
+    @remembering_for_reload
+    @isolated
+    def make_request(self, method, url, data=None, headers=None,
+                     referer_url=None):
+        if headers is None:
+            headers = {}
+
+        # The prepared_request is from the requests library and will be used
+        # for extracting the cookies later. It is not used while publishing.
+        # The zope_request is used for publishing.
+        prepared_request, zope_request, response = self._prepare_for_request(
+            method=method,
+            url=url,
+            data=data,
+            headers=headers,
+            referer_url=referer_url)
+
+        # RequestContainer / Request Acquisition:
+        # Views may get the request object through acquisition, for instance
+        # by calling ``context.REQUEST``.
+        # This works because the application object is acquisition wrapped
+        # with a ``RequestContainer`` instance, which has a pointer to the
+        # current request object.
+        # Since we need to make sure that this is the request constructed
+        # by the traversal driver, we need to unwrap the application and rewrap
+        # it with a new ``RequestContainer`` instance.
+        # If we would not do that views would end up with the test request.
+        requestcontainer = RequestContainer(REQUEST=zope_request)
+        app = aq_base(self.browser.app).__of__(requestcontainer)
+
+        with self.transactions_manager(zope_request, app):
+            try:
+                publish_module(
+                    'Zope2',
+                    response=response,
+                    request=zope_request,
+                    debug=self.browser.exception_bubbling)
+
+            except:
+                self.response = None
+                self.current_url = None
+                raise
+
+        self._extract_cookies(prepared_request, response)
+        self.response = response
+        self.current_url = prepared_request.url
+
+        if self.response.status in (301, 302, 303):
+            return self._follow_redirects(method, data, headers)
+        else:
+            return (self.response.status,
+                    self.response.errmsg,
+                    StringIO(self.response.body))
+
+    def _prepare_for_request(self, method, url, data, headers, referer_url):
+        if referer_url:
+            headers['REFERER'] = referer_url.strip()
+            headers['HTTP_REFERER'] = referer_url.strip()
+        else:
+            headers['REFERER'] = ''
+            headers['HTTP_REFERER'] = ''
+
+        # Use the requests library for creating a request because it can make
+        # the body string for us (e.g. multipart MIME bodies).
+        request = self.requests_session.prepare_request(
+            requests.models.Request(
+                method=method,
+                url=url,
+                data=data,
+                headers=headers))
+
+        urlinfo = urlparse(request.url)
+        env = {
+            'ACTUAL_URL': request.url,
+            'HTTP_HOST': urlinfo.hostname,
+            'PATH_INFO': unquote(urlinfo.path),
+            'PATH_TRANSLATED': urlinfo.path,
+            'QUERY_STRING': urlinfo.query,
+            'REQUEST_METHOD': request.method,
+            'SERVER_NAME': urlinfo.hostname,
+            'SERVER_PORT': str(urlinfo.port or 80),
+        }
+
+        for name, value in request.headers.items():
+            name = ('_'.join(name.upper().split('-')))
+            if name not in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
+                name = 'HTTP_' + name
+
+            env[name] = value.rstrip()
+
+        env['HTTP_CONNECTION'] = 'close'
+        env['HTTP_USER_AGENT'] = 'ftw.testbrowser/traversaldriver'
+
+        response = TestResponse(stdout=StringIO(), stderr=sys.stderr)
+
+        # craft a new zope request
+        zrequest = ZPublisher.Request.Request(
+            stdin=StringIO(request.body or ''),
+            environ=env,
+            response=response)
+
+        return request, zrequest, response
+
+    def _extract_cookies(self, request, response):
+        """Extract the cookies from the response into the current
+        requests session.
+
+        :param request: requests library request object
+        :type request: :py:class:`requests.models.PreparedRequest`
+        :param response: our drivers own testresponse
+        :type response:
+          :py:class:`ftw.testbrowser.drivers.traversaldriver.TestResponse`
+        """
+        # inspired by requests.cookies.extract_cookies_to_jar
+
+        # Prepare the request object for cookielib compatibility:
+        req = requests.cookies.MockRequest(request)
+
+        # Prepare the response object for cookielib compatibility:
+        res = requests.cookies.MockResponse(
+            httplib.HTTPMessage(StringIO(response.stdout.getvalue())))
+
+        self.requests_session.cookies.extract_cookies(res, req)
+
+    def _follow_redirects(self, method, data, headers):
+        redirect_url = self.get_response_headers().get('Location')
+        if headers.get('X-Testbrowser-Last-Redirect-Location') == redirect_url:
+            raise RedirectLoopException(redirect_url)
+        else:
+            headers['X-Testbrowser-Last-Redirect-Location'] = redirect_url
+
+        # https://stackoverflow.com/a/8138447
+        if (self.response.status == 303 and method.lower != 'head') or \
+           (self.response.status == 301 and method.lower() == 'post') or \
+           (self.response.status == 302 and method.lower() == 'post'):
+            redirect_method = 'GET'
+            redirect_data = None
+        else:
+            redirect_method = method
+            redirect_data = data
+
+        return self.make_request(method=redirect_method,
+                                 url=redirect_url,
+                                 data=redirect_data,
+                                 headers=headers.copy(),
+                                 referer_url=self.current_url)
+
+    def reload(self):
+        if self.previous_make_request is None:
+            raise BlankPage('Cannot reload.')
+        return self.previous_make_request()
+
+    def get_response_body(self):
+        if self.response is None:
+            raise BlankPage()
+        return self.response.body
+
+    def get_url(self):
+        return self.current_url
+
+    def get_response_headers(self):
+        if self.response is None:
+            return {}
+        return CaseInsensitiveDict(self.response.headers)
+
+    def get_response_cookies(self):
+        cookies = {}
+        cookiejar = self.requests_session.cookies
+        for domain_cookies in cookiejar._cookies.values():
+            for path_cookies in domain_cookies.values():
+                for cookie_name, cookie in path_cookies.items():
+                    cookies[cookie_name] = vars(cookie)
+        return cookies
+
+    def append_request_header(self, name, value):
+        if name in self.requests_session.headers:
+            raise NameError(
+                ('There is already a header "{}" and the requests driver'
+                 ' does not support using the same header multiple times.')
+                .format(name))
+
+        self.requests_session.headers.update({name: value.strip()})
+
+    def clear_request_header(self, name):
+        if name in self.requests_session.headers:
+            del self.requests_session.headers[name]
+
+    def cloned(self, subbrowser):
+        subdriver = subbrowser.get_driver(self.LIBRARY_NAME)
+        requests.cookies.merge_cookies(subdriver.requests_session.cookies,
+                                       self.requests_session.cookies)

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -94,6 +94,17 @@ class ContextNotFound(BrowserException):
         Exception.__init__(self, message)
 
 
+class RedirectLoopException(BrowserException):
+    """The server returned a redirect response that would lead to
+    an infinite redirect loop.
+    """
+
+    def __init__(self, url):
+        message = re.sub(r'\s+', ' ', self.__doc__.strip())
+        message += '\nURL: {}'.format(url)
+        Exception.__init__(self, message)
+
+
 class HTTPError(IOError):
     """The request has failed.
 

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -4,6 +4,7 @@ from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
 from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
 from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
+from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -46,6 +47,12 @@ class BrowserLayer(PloneSandboxLayer):
 
 
 BROWSER_FIXTURE = BrowserLayer()
+
+TRAVERSAL_TESTING = FunctionalTesting(
+    bases=(BROWSER_FIXTURE,
+           set_builder_session_factory(functional_session_factory),
+           TRAVERSAL_BROWSER_FIXTURE),
+    name='ftw.testbrowser:functional:traversal')
 
 MECHANIZE_TESTING = FunctionalTesting(
     bases=(BROWSER_FIXTURE,

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -1,3 +1,5 @@
+from ftw.testbrowser import browser
+from ftw.testbrowser import LIB_TRAVERSAL
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -10,14 +12,31 @@ class FunctionalTestCase(TestCase):
     def setUp(self):
         self.portal = self.layer['portal']
 
+    def transactions_enabled(self):
+        """Returns a boolean indicating whether we are currently using
+        transactions.
+        We are not using transactions when the layer is not a functional
+        testing layer.
+        We are not using transactions when the traversal driver is active,
+        since the idea of the traversal driver is that it can be used without
+        transactions and it therefore does not commit anything nor rely on
+        a commited transaction.
+        """
+        if not isinstance(self.layer, FunctionalTesting):
+            return False
+        if browser.default_driver == LIB_TRAVERSAL:
+            return False
+        return True
+
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, list(roles))
-        if isinstance(self.layer, FunctionalTesting):
+        if self.transactions_enabled():
             transaction.commit()
 
     def sync_transaction(self):
-        # Especially with the requests driver we sometimes need to sync
-        # the transaction in order to get hold of new transactions committed
-        # on another thread.
-        if isinstance(self.layer, FunctionalTesting):
+        """Especially with the requests driver we sometimes need to sync
+        the transaction in order to get hold of new transactions committed
+        on another thread or on another connection.
+        """
+        if self.transactions_enabled():
             transaction.begin()

--- a/ftw/testbrowser/tests/test_cookies.py
+++ b/ftw/testbrowser/tests/test_cookies.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_MECHANIZE
+from ftw.testbrowser.core import LIB_TRAVERSAL
 from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.alldrivers import skip_driver
@@ -24,6 +25,9 @@ class TestCookies(FunctionalTestCase):
 
 
     @skip_driver(LIB_MECHANIZE, """
+    The `webdav` method can only be used with a running ZServer.
+    """)
+    @skip_driver(LIB_TRAVERSAL, """
     The `webdav` method can only be used with a running ZServer.
     """)
     @browsing

--- a/ftw/testbrowser/tests/test_driver_layers.py
+++ b/ftw/testbrowser/tests/test_driver_layers.py
@@ -1,8 +1,10 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
 from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
+from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.core import LIB_TRAVERSAL
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from unittest2 import TestCase
@@ -30,3 +32,15 @@ class TestRequestsFixture(TestCase):
     @browsing
     def test(self, browser):
         self.assertEquals(LIB_REQUESTS, browser.get_driver().LIBRARY_NAME)
+
+
+class TestTraversalFixture(TestCase):
+
+    layer = FunctionalTesting(
+        bases=(PLONE_FIXTURE,
+               TRAVERSAL_BROWSER_FIXTURE),
+        name='functional:traversal')
+
+    @browsing
+    def test(self, browser):
+        self.assertEquals(LIB_TRAVERSAL, browser.get_driver().LIBRARY_NAME)

--- a/ftw/testbrowser/tests/test_driver_utils.py
+++ b/ftw/testbrowser/tests/test_driver_utils.py
@@ -1,13 +1,31 @@
+from AccessControl.SecurityManagement import getSecurityManager
+from AccessControl.SecurityManagement import newSecurityManager
 from ftw.testbrowser.drivers.utils import isolate_globalrequest
+from ftw.testbrowser.drivers.utils import isolate_securitymanager
+from ftw.testbrowser.drivers.utils import isolate_sitehook
 from ftw.testbrowser.drivers.utils import isolated
 from ftw.testbrowser.testing import DEFAULT_TESTING
 from ftw.testbrowser.tests import FunctionalTestCase
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import TEST_USER_ID
+from Products.CMFPlone.Portal import PloneSite
+from zope.component.hooks import getSite
+from zope.component.hooks import setSite
 from zope.globalrequest import getRequest
 from zope.globalrequest import setRequest
 
 
 class TestIsolation(FunctionalTestCase):
     layer = DEFAULT_TESTING
+
+    def test_isolate_globalrequest(self):
+        setRequest(self.layer['request'])
+
+        with isolate_globalrequest():
+            self.assertIsNone(None, getRequest())
+            setRequest('bar')
+
+        self.assertEquals(self.layer['request'], getRequest())
 
     def test_decorator_isolates_globalrequest(self):
         setRequest(self.layer['request'])
@@ -21,11 +39,46 @@ class TestIsolation(FunctionalTestCase):
         self.assertEquals('Foo', foo())
         self.assertEquals(self.layer['request'], getRequest())
 
-    def test_isolate_globalrequest(self):
-        setRequest(self.layer['request'])
+    def test_isolate_sitehook(self):
+        setSite(self.layer['portal'])
 
-        with isolate_globalrequest():
-            self.assertIsNone(None, getRequest())
-            setRequest('bar')
+        with isolate_sitehook():
+            self.assertIsNone(None, getSite())
+            setSite(PloneSite('fakesite'))
 
-        self.assertEquals(self.layer['request'], getRequest())
+        self.assertEquals(self.layer['portal'], getSite())
+
+    def test_decorator_isolates_sitehook(self):
+        setSite(self.layer['portal'])
+
+        @isolated
+        def foo():
+            self.assertIsNone(None, getSite())
+            setSite(PloneSite('fakesite'))
+            return 'Foo'
+
+        self.assertEquals('Foo', foo())
+        self.assertEquals(self.layer['portal'], getSite())
+
+    def test_isolate_securitymanager(self):
+        newSecurityManager(self.layer['portal'], TEST_USER_ID)
+        security_manager = getSecurityManager()
+
+        with isolate_securitymanager():
+            self.assertIsNone(None, getSecurityManager())
+            newSecurityManager(self.layer['portal'], SITE_OWNER_NAME)
+
+        self.assertEquals(security_manager, getSecurityManager())
+
+    def test_decorator_isolates_security_manager(self):
+        newSecurityManager(self.layer['portal'], TEST_USER_ID)
+        security_manager = getSecurityManager()
+
+        @isolated
+        def foo():
+            self.assertIsNone(None, getSecurityManager())
+            newSecurityManager(self.layer['portal'], SITE_OWNER_NAME)
+            return 'Foo'
+
+        self.assertEquals('Foo', foo())
+        self.assertEquals(security_manager, getSecurityManager())

--- a/ftw/testbrowser/tests/test_drivers_traversaldriver.py
+++ b/ftw/testbrowser/tests/test_drivers_traversaldriver.py
@@ -1,0 +1,45 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
+from ftw.testbrowser.exceptions import RedirectLoopException
+from ftw.testbrowser.interfaces import IDriver
+from ftw.testbrowser.testing import TRAVERSAL_TESTING
+from ftw.testbrowser.tests import FunctionalTestCase
+from plone.app.testing import SITE_OWNER_NAME
+from zope.interface.verify import verifyClass
+import transaction
+
+
+class TestTraversalDriverImplementation(FunctionalTestCase):
+    layer = TRAVERSAL_TESTING
+
+    def test_implements_interface(self):
+        verifyClass(IDriver, TraversalDriver)
+
+    @browsing
+    def test_does_not_require_transaction_commit(self, browser):
+        self.portal.setTitle('New Plone Site')
+        browser.open()
+        self.assertEquals('New Plone Site', browser.css('title').first.text)
+
+    @browsing
+    def test_does_not_commit_transactions(self, browser):
+        self.assertEquals('Plone site', self.portal.Title())
+        browser.login(SITE_OWNER_NAME).open(view='edit')
+        browser.fill({'Site title': 'New site title'}).save()
+
+        self.assertEquals('New site title', self.portal.Title())
+        transaction.begin()  # reset to last commited state
+        self.assertEquals(
+            'Plone site', self.portal.Title(),
+            'The traversal driver should not commit the transaction.')
+
+    @browsing
+    def test_redirect_loops_are_interrupted(self, browser):
+        with self.assertRaises(RedirectLoopException) as cm:
+            browser.open(view='test-redirect-loop')
+
+        self.assertEquals(
+            'The server returned a redirect response that would lead'
+            ' to an infinite redirect loop.\n'
+            'URL: http://nohost/plone/test-redirect-loop',
+            str(cm.exception))

--- a/ftw/testbrowser/tests/test_headers.py
+++ b/ftw/testbrowser/tests/test_headers.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_MECHANIZE
+from ftw.testbrowser.core import LIB_TRAVERSAL
 from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.alldrivers import skip_driver
@@ -16,6 +17,9 @@ class TestMechanizeHeaders(FunctionalTestCase):
                        'text/html;charset=utf-8'))
 
     @skip_driver(LIB_MECHANIZE, """
+    The `webdav` method can only be used with a running ZServer.
+    """)
+    @skip_driver(LIB_TRAVERSAL, """
     The `webdav` method can only be used with a running ZServer.
     """)
     @browsing

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
+from ftw.testbrowser.core import LIB_TRAVERSAL
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import FunctionalTestCase
@@ -77,7 +78,8 @@ class TestBrowserRequests(FunctionalTestCase):
 
             self.assertEquals('The value is wrong.', str(cm.exception))
 
-    @skip_driver(LIB_MECHANIZE, 'Exception bubbling is supported.')
+    @skip_driver(LIB_MECHANIZE, 'Exception bubbling is supported by mechanize.')
+    @skip_driver(LIB_TRAVERSAL, 'Exception bubbling is supported by traversal.')
     @browsing
     def test_unsupport_exception_bubbling(self, browser):
         browser.exception_bubbling = True
@@ -370,3 +372,10 @@ class TestBrowserRequests(FunctionalTestCase):
 
         browser.logout().open()
         self.assertFalse(plone.logged_in())
+
+    @browsing
+    def test_redirects_are_followed_automatically(self, browser):
+        browser.open(view='test-redirect-to-portal')
+        self.assertEquals(self.portal.absolute_url(), browser.url)
+        self.assertEquals(('listing_view', 'plone-site'),
+                          plone.view_and_portal_type())

--- a/ftw/testbrowser/tests/views/configure.zcml
+++ b/ftw/testbrowser/tests/views/configure.zcml
@@ -80,4 +80,18 @@
         name="test-z3cform-payment-vocabulary"
         />
 
+    <browser:page
+        name="test-redirect-to-portal"
+        class=".views.TestRedirectToPortal"
+        for="*"
+        permission="zope.Public"
+        />
+
+    <browser:page
+        name="test-redirect-loop"
+        class=".views.TestRedirectLoop"
+        for="*"
+        permission="zope.Public"
+        />
+
 </configure>

--- a/ftw/testbrowser/tests/views/views.py
+++ b/ftw/testbrowser/tests/views/views.py
@@ -81,3 +81,16 @@ class TestAsset(BrowserView):
 
         with open(path, 'rb') as file_:
             return file_.read()
+
+
+class TestRedirectToPortal(BrowserView):
+
+    def __call__(self):
+        portal_url = getToolByName(self.context, 'portal_url')()
+        return self.request.response.redirect(portal_url)
+
+
+class TestRedirectLoop(BrowserView):
+
+    def __call__(self):
+        return self.request.response.redirect(self.request['ACTUAL_URL'])


### PR DESCRIPTION
The traversal driver executes the requests by traversing internally in the same transaction and with the same connection as the test.

The advantage of the traversal driver is that it does not need uncommitted state to be committed, nor does it commit modifications happening in the request.

// cc @4teamwork/gever @buchi @maethu 