### PR TITLE
Fix `browser.context` when base_url ends with a view name.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix `browser.context` when base_url ends with a view name. [phgross]
 
 
 1.23.1 (2017-05-02)

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_chain
 from contextlib import contextmanager
 from copy import deepcopy
 from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
@@ -18,6 +19,7 @@ from ftw.testbrowser.nodes import wrapped_nodes
 from ftw.testbrowser.utils import normalize_spaces
 from ftw.testbrowser.utils import parse_html
 from lxml.cssselect import CSSSelector
+from OFS.interfaces import IItem
 from operator import attrgetter
 from operator import methodcaller
 from StringIO import StringIO
@@ -781,7 +783,10 @@ class Browser(object):
                 ' path "%s" but it is "%s"') % (portal_path, path))
 
         relative_path = path[len(portal_path + '/'):]
-        return portal.restrictedTraverse(relative_path)
+        obj = portal.restrictedTraverse(relative_path)
+
+        # Make sure it returns the context object not a traversable view.
+        return filter(IItem.providedBy, aq_chain(obj))[0]
 
     def parse_as_html(self, html=None):
         """Parse the response document with the HTML parser.

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -2,8 +2,11 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import ContextNotFound
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import FunctionalTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
@@ -24,6 +27,18 @@ class TestBrowserContext(FunctionalTestCase):
         folder = create(Builder('folder').titled(u'The Folder'))
         browser.login().visit(folder, view='folder_contents')
         self.assertEquals(folder, browser.context)
+
+    @browsing
+    def test_context_when_url_contains_view(self, browser):
+        browser.login(SITE_OWNER_NAME).open()
+        factoriesmenu.add('Page')
+
+        browser.fill({'Title': u'Page',
+                      'Exclude from navigation': True}).save()
+        statusmessages.assert_no_error_messages()
+        self.sync_transaction()
+
+        self.assertEquals(self.portal.get('page'), browser.context)
 
     @browsing
     def test_execption_when_not_viewing_any_page(self, browser):

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.11.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
 
 package-name = ftw.testbrowser


### PR DESCRIPTION
With the newest plone 4.3.x version, the base_url contains the view name in some cases, therefore the `browser.context` getter has to make sure that the traversed object is really an object not a view.

This should fixes issues with the newest latest Plone 4.3 version and reverts 043e73760c3c5663e955a25296a87d2b1bb4caae