### PR TITLE
Run integrationt tests with traversal driver.

### DIFF
--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -7,6 +7,7 @@ from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PLONE_ZSERVER
 from plone.app.testing import PloneSandboxLayer
@@ -53,6 +54,11 @@ TRAVERSAL_TESTING = FunctionalTesting(
            set_builder_session_factory(functional_session_factory),
            TRAVERSAL_BROWSER_FIXTURE),
     name='ftw.testbrowser:functional:traversal')
+
+TRAVERSAL_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(BROWSER_FIXTURE,
+           TRAVERSAL_BROWSER_FIXTURE),
+    name='ftw.testbrowser:integration:traversal')
 
 MECHANIZE_TESTING = FunctionalTesting(
     bases=(BROWSER_FIXTURE,

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -7,7 +7,7 @@ from unittest2 import TestCase
 import transaction
 
 
-class FunctionalTestCase(TestCase):
+class BrowserTestCase(TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']

--- a/ftw/testbrowser/tests/alldrivers.py
+++ b/ftw/testbrowser/tests/alldrivers.py
@@ -3,6 +3,7 @@ from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.core import LIB_TRAVERSAL
 from ftw.testbrowser.testing import MECHANIZE_TESTING
 from ftw.testbrowser.testing import REQUESTS_TESTING
+from ftw.testbrowser.testing import TRAVERSAL_INTEGRATION_TESTING
 from ftw.testbrowser.testing import TRAVERSAL_TESTING
 from unittest2 import skip
 import sys
@@ -17,6 +18,7 @@ def all_drivers(testcase):
         ('Mechanize', MECHANIZE_TESTING, LIB_MECHANIZE),
         ('Requests', REQUESTS_TESTING, LIB_REQUESTS),
         ('Traversal', TRAVERSAL_TESTING, LIB_TRAVERSAL),
+        ('TraversalIntegration', TRAVERSAL_INTEGRATION_TESTING, LIB_TRAVERSAL),
     )
     testcase._testbrowser_abstract_testclass = True
 

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -5,7 +5,7 @@ from ftw.testbrowser import HTTPServerError
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import register_view
 from plone.app.testing import SITE_OWNER_NAME
@@ -37,7 +37,7 @@ AC_COOKIE_INFO = {'comment': None,
 
 
 @all_drivers
-class TestBrowserCore(FunctionalTestCase):
+class TestBrowserCore(BrowserTestCase):
 
     @browsing
     def test_contents(self, browser):

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -4,13 +4,13 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import ContextNotFound
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
-class TestBrowserContext(FunctionalTestCase):
+class TestBrowserContext(BrowserTestCase):
 
     def setUp(self):
         super(TestBrowserContext, self).setUp()

--- a/ftw/testbrowser/tests/test_cookies.py
+++ b/ftw/testbrowser/tests/test_cookies.py
@@ -1,7 +1,7 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_TRAVERSAL
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.alldrivers import skip_driver
 from plone.app.testing import TEST_USER_NAME
@@ -9,7 +9,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 
 
 @all_drivers
-class TestCookies(FunctionalTestCase):
+class TestCookies(BrowserTestCase):
 
     @browsing
     def test_cookies(self, browser):

--- a/ftw/testbrowser/tests/test_defaultdriver.py
+++ b/ftw/testbrowser/tests/test_defaultdriver.py
@@ -4,10 +4,10 @@ from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.testing import DEFAULT_TESTING
 from ftw.testbrowser.testing import REQUESTS_TESTING
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 
 
-class TestDefaultDriver(FunctionalTestCase):
+class TestDefaultDriver(BrowserTestCase):
     layer = DEFAULT_TESTING
 
     def test_library_constants_without_zopeapp(self):
@@ -33,7 +33,7 @@ class TestDefaultDriver(FunctionalTestCase):
             self.assertEquals(LIB_MECHANIZE, browser.get_driver().LIBRARY_NAME)
 
 
-class TestSwitchToRequestDriver(FunctionalTestCase):
+class TestSwitchToRequestDriver(BrowserTestCase):
     layer = REQUESTS_TESTING
 
     @browsing

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -2,14 +2,14 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
 from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
-class TestDexterityForms(FunctionalTestCase):
+class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_tinymce_formfill(self, browser):

--- a/ftw/testbrowser/tests/test_driver_utils.py
+++ b/ftw/testbrowser/tests/test_driver_utils.py
@@ -5,7 +5,7 @@ from ftw.testbrowser.drivers.utils import isolate_securitymanager
 from ftw.testbrowser.drivers.utils import isolate_sitehook
 from ftw.testbrowser.drivers.utils import isolated
 from ftw.testbrowser.testing import DEFAULT_TESTING
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 from Products.CMFPlone.Portal import PloneSite
@@ -15,7 +15,7 @@ from zope.globalrequest import getRequest
 from zope.globalrequest import setRequest
 
 
-class TestIsolation(FunctionalTestCase):
+class TestIsolation(BrowserTestCase):
     layer = DEFAULT_TESTING
 
     def test_isolate_globalrequest(self):

--- a/ftw/testbrowser/tests/test_drivers_requestsdriver.py
+++ b/ftw/testbrowser/tests/test_drivers_requestsdriver.py
@@ -2,11 +2,11 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.drivers.requestsdriver import RequestsDriver
 from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.testing import REQUESTS_TESTING
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from zope.interface.verify import verifyClass
 
 
-class TestRequestsDriverImplementation(FunctionalTestCase):
+class TestRequestsDriverImplementation(BrowserTestCase):
     layer = REQUESTS_TESTING
 
     def test_implements_interface(self):

--- a/ftw/testbrowser/tests/test_drivers_traversaldriver.py
+++ b/ftw/testbrowser/tests/test_drivers_traversaldriver.py
@@ -3,13 +3,13 @@ from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
 from ftw.testbrowser.exceptions import RedirectLoopException
 from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.testing import TRAVERSAL_TESTING
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from plone.app.testing import SITE_OWNER_NAME
 from zope.interface.verify import verifyClass
 import transaction
 
 
-class TestTraversalDriverImplementation(FunctionalTestCase):
+class TestTraversalDriverImplementation(BrowserTestCase):
     layer = TRAVERSAL_TESTING
 
     def test_implements_interface(self):

--- a/ftw/testbrowser/tests/test_elements.py
+++ b/ftw/testbrowser/tests/test_elements.py
@@ -1,10 +1,10 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestBrowserRequestsMechanize(FunctionalTestCase):
+class TestBrowserRequestsMechanize(BrowserTestCase):
 
     @browsing
     def test_find_link_by_text(self, browser):

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -5,7 +5,7 @@ from ftw.testbrowser.form import Form
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.widgets.base import PloneWidget
 from plone.app.testing import SITE_OWNER_NAME
@@ -16,7 +16,7 @@ import lxml.html
 
 
 @all_drivers
-class TestBrowserForms(FunctionalTestCase):
+class TestBrowserForms(BrowserTestCase):
 
     @browsing
     def test_find_form_by_field_label(self, browser):
@@ -205,7 +205,7 @@ class TestBrowserForms(FunctionalTestCase):
 
 
 @all_drivers
-class TestSubmittingForms(FunctionalTestCase):
+class TestSubmittingForms(BrowserTestCase):
 
     @browsing
     def test_should_send_default_submit_button_value(self, browser):
@@ -280,7 +280,7 @@ class TestSubmittingForms(FunctionalTestCase):
 
 
 @all_drivers
-class TestSelectField(FunctionalTestCase):
+class TestSelectField(BrowserTestCase):
 
     @browsing
     def test_select_value(self, browser):

--- a/ftw/testbrowser/tests/test_headers.py
+++ b/ftw/testbrowser/tests/test_headers.py
@@ -1,13 +1,13 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_TRAVERSAL
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.alldrivers import skip_driver
 
 
 @all_drivers
-class TestMechanizeHeaders(FunctionalTestCase):
+class TestMechanizeHeaders(BrowserTestCase):
 
     @browsing
     def test_headers(self, browser):

--- a/ftw/testbrowser/tests/test_nodes.py
+++ b/ftw/testbrowser/tests/test_nodes.py
@@ -6,12 +6,12 @@ from ftw.testbrowser.nodes import LinkNode
 from ftw.testbrowser.nodes import Nodes
 from ftw.testbrowser.nodes import NodeWrapper
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestNodesResultSet(FunctionalTestCase):
+class TestNodesResultSet(BrowserTestCase):
 
     @browsing
     def test_text_content_for_many_elements(self, browser):
@@ -269,7 +269,7 @@ class TestNodesResultSet(FunctionalTestCase):
 
 
 @all_drivers
-class TestNodeWrappers(FunctionalTestCase):
+class TestNodeWrappers(BrowserTestCase):
 
     def test_reference_to_browser(self):
         with Browser()(self.layer['app']) as browser:
@@ -684,7 +684,7 @@ class TestNodeWrappers(FunctionalTestCase):
 
 
 @all_drivers
-class TestNodeComparison(FunctionalTestCase):
+class TestNodeComparison(BrowserTestCase):
 
     @browsing
     def test_comparing_two_elements_representing_the_same_node(self, browser):
@@ -703,7 +703,7 @@ class TestNodeComparison(FunctionalTestCase):
 
 
 @all_drivers
-class TestLinkNode(FunctionalTestCase):
+class TestLinkNode(BrowserTestCase):
 
     @browsing
     def test_clicking_links(self, browser):
@@ -728,7 +728,7 @@ class TestLinkNode(FunctionalTestCase):
 
 
 @all_drivers
-class TestDefinitionListNode(FunctionalTestCase):
+class TestDefinitionListNode(BrowserTestCase):
 
     @browsing
     def test_keys_returns_dts(self, browser):

--- a/ftw/testbrowser/tests/test_pages_dexterity.py
+++ b/ftw/testbrowser/tests/test_pages_dexterity.py
@@ -1,12 +1,12 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import dexterity
 from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestDexterityPageObject(FunctionalTestCase):
+class TestDexterityPageObject(BrowserTestCase):
 
     @browsing
     def test_erroneous_fields(self, browser):

--- a/ftw/testbrowser/tests/test_pages_factoriesmenu.py
+++ b/ftw/testbrowser/tests/test_pages_factoriesmenu.py
@@ -2,12 +2,12 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestFactoriesMenu(FunctionalTestCase):
+class TestFactoriesMenu(BrowserTestCase):
 
     @browsing
     def test_factoriesmenu_visible(self, browser):

--- a/ftw/testbrowser/tests/test_pages_folder_contents.py
+++ b/ftw/testbrowser/tests/test_pages_folder_contents.py
@@ -3,12 +3,12 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import folder_contents
 from ftw.testbrowser.table import TableRow
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestFolderContents(FunctionalTestCase):
+class TestFolderContents(BrowserTestCase):
 
     def setUp(self):
         super(TestFolderContents, self).setUp()

--- a/ftw/testbrowser/tests/test_pages_plone.py
+++ b/ftw/testbrowser/tests/test_pages_plone.py
@@ -1,14 +1,14 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 
 
 @all_drivers
-class TestPlonePageObject(FunctionalTestCase):
+class TestPlonePageObject(BrowserTestCase):
 
     @browsing
     def test_not_logged_in(self, browser):

--- a/ftw/testbrowser/tests/test_pages_statusmessages.py
+++ b/ftw/testbrowser/tests/test_pages_statusmessages.py
@@ -1,11 +1,11 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestStatusmessages(FunctionalTestCase):
+class TestStatusmessages(BrowserTestCase):
 
     @browsing
     def test_messages(self, browser):

--- a/ftw/testbrowser/tests/test_pages_z3cform.py
+++ b/ftw/testbrowser/tests/test_pages_z3cform.py
@@ -1,12 +1,12 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import z3cform
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestZ3cformPageObject(FunctionalTestCase):
+class TestZ3cformPageObject(BrowserTestCase):
 
     @browsing
     def test_erroneous_fields(self, browser):

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -6,7 +6,7 @@ from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.core import LIB_TRAVERSAL
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.alldrivers import skip_driver
 from ftw.testbrowser.tests.helpers import register_view
@@ -19,7 +19,7 @@ from zope.publisher.browser import BrowserView
 
 
 @all_drivers
-class TestBrowserRequests(FunctionalTestCase):
+class TestBrowserRequests(BrowserTestCase):
 
     def setUp(self):
         super(TestBrowserRequests, self).setUp()

--- a/ftw/testbrowser/tests/test_session.py
+++ b/ftw/testbrowser/tests/test_session.py
@@ -1,6 +1,6 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import plone
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
@@ -8,7 +8,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 
 
 @all_drivers
-class TestBrowserSession(FunctionalTestCase):
+class TestBrowserSession(BrowserTestCase):
 
     @browsing
     def test_browser_stays_logged_in(self, browser):

--- a/ftw/testbrowser/tests/test_tables.py
+++ b/ftw/testbrowser/tests/test_tables.py
@@ -1,13 +1,13 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.table import colspan_padded_text
 from ftw.testbrowser.table import TableCell
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from operator import attrgetter
 
 
 @all_drivers
-class TestTables(FunctionalTestCase):
+class TestTables(BrowserTestCase):
 
     @browsing
     def test_find_cell_by_text_on_table(self, browser):
@@ -292,7 +292,7 @@ class TestTables(FunctionalTestCase):
 
 
 @all_drivers
-class TestTableRow(FunctionalTestCase):
+class TestTableRow(BrowserTestCase):
 
     @browsing
     def test_table_attribute_is_table_object(self, browser):
@@ -390,7 +390,7 @@ class TestTableRow(FunctionalTestCase):
 
 
 @all_drivers
-class TestTableCell(FunctionalTestCase):
+class TestTableCell(BrowserTestCase):
 
     @browsing
     def test_table_attribute_is_table_object(self, browser):

--- a/ftw/testbrowser/tests/test_webdav_requests.py
+++ b/ftw/testbrowser/tests/test_webdav_requests.py
@@ -3,10 +3,10 @@ from ftw.testbrowser.exceptions import ZServerRequired
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.testing import MECHANIZE_TESTING
 from ftw.testbrowser.testing import REQUESTS_TESTING
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 
 
-class TestWebdavRequests(FunctionalTestCase):
+class TestWebdavRequests(BrowserTestCase):
     layer = REQUESTS_TESTING
 
     @browsing
@@ -34,7 +34,7 @@ class TestWebdavRequests(FunctionalTestCase):
                           browser.xpath('//d:displayname').first.text)
 
 
-class TestNoZserverWebdavRequests(FunctionalTestCase):
+class TestNoZserverWebdavRequests(BrowserTestCase):
     layer = MECHANIZE_TESTING
 
     @browsing

--- a/ftw/testbrowser/tests/test_widgets_autocomplete.py
+++ b/ftw/testbrowser/tests/test_widgets_autocomplete.py
@@ -1,12 +1,12 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 from urlparse import urljoin
 
 
 @all_drivers
-class TestBrowserZ3CForms(FunctionalTestCase):
+class TestBrowserZ3CForms(BrowserTestCase):
 
     @browsing
     def test_autocomplete_form_fill(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_contenttree.py
+++ b/ftw/testbrowser/tests/test_widgets_contenttree.py
@@ -1,13 +1,13 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
-class TestContentTreeWidget(FunctionalTestCase):
+class TestContentTreeWidget(BrowserTestCase):
 
     def setUp(self):
         super(TestContentTreeWidget, self).setUp()

--- a/ftw/testbrowser/tests/test_widgets_datagrid.py
+++ b/ftw/testbrowser/tests/test_widgets_datagrid.py
@@ -1,22 +1,18 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testing import staticuid
-from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
-import transaction
 
 
 @all_drivers
-class TestDexterityDataGridWidget(FunctionalTestCase):
+class TestDexterityDataGridWidget(BrowserTestCase):
 
     @browsing
     @staticuid()
     def test_datagrid_form_fill(self, browser):
-        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
-        transaction.commit()
+        self.grant('Manager')
         browser.login().visit(view='test-z3cform-shopping')
 
         browser.fill({'Cakes': [

--- a/ftw/testbrowser/tests/test_widgets_date.py
+++ b/ftw/testbrowser/tests/test_widgets_date.py
@@ -1,12 +1,12 @@
 from datetime import date
 from ftw.testbrowser import browsing
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
-class TestDateWidget(FunctionalTestCase):
+class TestDateWidget(BrowserTestCase):
 
     @browsing
     def test_z3cform_datefield_formfill(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_datetime.py
+++ b/ftw/testbrowser/tests/test_widgets_datetime.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
-class TestDatetimeWidget(FunctionalTestCase):
+class TestDatetimeWidget(BrowserTestCase):
 
     @browsing
     def test_z3cform_formfill(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_file.py
+++ b/ftw/testbrowser/tests/test_widgets_file.py
@@ -1,14 +1,14 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import asset
 from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
-class TestDexterityFileUploadWidget(FunctionalTestCase):
+class TestDexterityFileUploadWidget(BrowserTestCase):
 
     @browsing
     def test_filling_file_upload_widget_by_label(self, browser):

--- a/ftw/testbrowser/tests/test_widgets_sequence.py
+++ b/ftw/testbrowser/tests/test_widgets_sequence.py
@@ -1,13 +1,13 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import OnlyOneValueAllowed
 from ftw.testbrowser.exceptions import OptionsNotFound
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
 
 
 @all_drivers
-class TestSequenceWidget(FunctionalTestCase):
+class TestSequenceWidget(BrowserTestCase):
 
     @browsing
     def test_sequence_widget_options(self, browser):

--- a/ftw/testbrowser/tests/test_xml_document.py
+++ b/ftw/testbrowser/tests/test_xml_document.py
@@ -1,10 +1,10 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.tests import FunctionalTestCase
+from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 
 
 @all_drivers
-class TestXMLDocument(FunctionalTestCase):
+class TestXMLDocument(BrowserTestCase):
 
     @browsing
     def test_utf8_document_with_umlaut(self, browser):


### PR DESCRIPTION
Runs all tests decorated with ``@all_drivers`` against a integration testing layer with the traversal request driver.
This makes sure that the testbrowser can actually be used in integration testing and it will hopefully uncover database isolation problems with the traversal request driver when the occur in the future.