### PR TITLE
Standardize redirect loop detection.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.23.3 (unreleased)
 -------------------
 
+- Standardize redirect loop detection: always throw a ``RedirectLoopException``. [jone]
 - Add traversal request driver. [jone]
 
 

--- a/ftw/testbrowser/drivers/mechdriver.py
+++ b/ftw/testbrowser/drivers/mechdriver.py
@@ -2,9 +2,11 @@ from ftw.testbrowser.drivers.utils import isolated
 from ftw.testbrowser.drivers.utils import remembering_for_reload
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
+from ftw.testbrowser.exceptions import RedirectLoopException
 from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.utils import copy_docs_from_interface
 from mechanize import Request
+from mechanize._urllib2_fork import HTTPRedirectHandler
 from requests.structures import CaseInsensitiveDict
 from zope.interface import implements
 import pkg_resources
@@ -60,6 +62,9 @@ class MechanizeDriver(object):
         try:
             self.response = self._get_mechbrowser().open(request)
         except urllib2.HTTPError as response:
+            if response.reason.startswith(HTTPRedirectHandler.inf_msg):
+                raise RedirectLoopException(response.geturl())
+
             self.response = response
         except:
             self.response = None

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -108,6 +108,7 @@ class RedirectLoopException(BrowserException):
         message = re.sub(r'\s+', ' ', self.__doc__.strip())
         message += '\nURL: {}'.format(url)
         Exception.__init__(self, message)
+        self.url = url
 
 
 class HTTPError(IOError):

--- a/ftw/testbrowser/tests/test_drivers_traversaldriver.py
+++ b/ftw/testbrowser/tests/test_drivers_traversaldriver.py
@@ -1,6 +1,5 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
-from ftw.testbrowser.exceptions import RedirectLoopException
 from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.testing import TRAVERSAL_TESTING
 from ftw.testbrowser.tests import BrowserTestCase
@@ -32,14 +31,3 @@ class TestTraversalDriverImplementation(BrowserTestCase):
         self.assertEquals(
             'Plone site', self.portal.Title(),
             'The traversal driver should not commit the transaction.')
-
-    @browsing
-    def test_redirect_loops_are_interrupted(self, browser):
-        with self.assertRaises(RedirectLoopException) as cm:
-            browser.open(view='test-redirect-loop')
-
-        self.assertEquals(
-            'The server returned a redirect response that would lead'
-            ' to an infinite redirect loop.\n'
-            'URL: http://nohost/plone/test-redirect-loop',
-            str(cm.exception))

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -5,6 +5,7 @@ from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.core import LIB_TRAVERSAL
 from ftw.testbrowser.exceptions import BlankPage
+from ftw.testbrowser.exceptions import RedirectLoopException
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
@@ -379,3 +380,14 @@ class TestBrowserRequests(BrowserTestCase):
         self.assertEquals(self.portal.absolute_url(), browser.url)
         self.assertEquals(('listing_view', 'plone-site'),
                           plone.view_and_portal_type())
+
+    @browsing
+    def test_redirect_loops_are_interrupted(self, browser):
+        with self.assertRaises(RedirectLoopException) as cm:
+            browser.open(view='test-redirect-loop')
+
+        self.assertEquals(
+            'The server returned a redirect response that would lead'
+            ' to an infinite redirect loop.\n'
+            'URL: {}/test-redirect-loop'.format(self.portal.absolute_url()),
+            str(cm.exception))


### PR DESCRIPTION
Standardize redirect loop detection so that all drivers throw a ``RedirectLoopException``, which knows the current url.
