### PR TITLE
Add WebDAV support to the traversal driver.

### DIFF
--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -14,6 +14,7 @@ from ftw.testbrowser.exceptions import HTTPClientError
 from ftw.testbrowser.exceptions import HTTPError
 from ftw.testbrowser.exceptions import HTTPServerError
 from ftw.testbrowser.exceptions import NoElementFound
+from ftw.testbrowser.exceptions import NoWebDAVSupport
 from ftw.testbrowser.interfaces import IBrowser
 from ftw.testbrowser.nodes import wrap_nodes
 from ftw.testbrowser.nodes import wrapped_nodes
@@ -316,7 +317,10 @@ class Browser(object):
         """
         self._verify_setup()
         url = self._normalize_url(url_or_object, view=view)
-        driver = self.get_driver(LIB_REQUESTS)
+        driver = self.get_driver()
+        if not driver.WEBDAV_SUPPORT:
+            raise NoWebDAVSupport()
+
         self._status_code, self._status_reason, body = driver.make_request(
             method, url, data=data, headers=headers)
         self.parse(body)

--- a/ftw/testbrowser/drivers/mechdriver.py
+++ b/ftw/testbrowser/drivers/mechdriver.py
@@ -29,6 +29,7 @@ class MechanizeDriver(object):
     implements(IDriver)
 
     LIBRARY_NAME = 'mechanize library'
+    WEBDAV_SUPPORT = False
 
     def __init__(self, browser):
         self.browser = browser

--- a/ftw/testbrowser/drivers/requestsdriver.py
+++ b/ftw/testbrowser/drivers/requestsdriver.py
@@ -18,6 +18,7 @@ class RequestsDriver(object):
     implements(IDriver)
 
     LIBRARY_NAME = 'requests library'
+    WEBDAV_SUPPORT = True
 
     def __init__(self, browser):
         self.browser = browser

--- a/ftw/testbrowser/drivers/staticdriver.py
+++ b/ftw/testbrowser/drivers/staticdriver.py
@@ -12,6 +12,7 @@ class StaticDriver(object):
     implements(IDriver)
 
     LIBRARY_NAME = 'static driver'
+    WEBDAV_SUPPORT = False
 
     def __init__(self, browser):
         self.browser = browser

--- a/ftw/testbrowser/drivers/traversaldriver.py
+++ b/ftw/testbrowser/drivers/traversaldriver.py
@@ -184,6 +184,7 @@ class TraversalDriver(object):
     implements(IDriver)
 
     LIBRARY_NAME = 'traversal library'
+    WEBDAV_SUPPORT = True
 
     def __init__(self, browser):
         self.browser = browser

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -63,6 +63,11 @@ class ZServerRequired(BrowserException):
     """
 
 
+class NoWebDAVSupport(BrowserException):
+    """The current testbrowser driver does not support webdav requests.
+    """
+
+
 class OptionsNotFound(BrowserException):
     """Could not find the options for a widget.
     """

--- a/ftw/testbrowser/tests/test_cookies.py
+++ b/ftw/testbrowser/tests/test_cookies.py
@@ -27,9 +27,6 @@ class TestCookies(BrowserTestCase):
     @skip_driver(LIB_MECHANIZE, """
     The `webdav` method can only be used with a running ZServer.
     """)
-    @skip_driver(LIB_TRAVERSAL, """
-    The `webdav` method can only be used with a running ZServer.
-    """)
     @browsing
     def test_webdav_cookies(self, browser):
         browser.open(view='login_form')

--- a/ftw/testbrowser/tests/test_headers.py
+++ b/ftw/testbrowser/tests/test_headers.py
@@ -19,9 +19,6 @@ class TestMechanizeHeaders(BrowserTestCase):
     @skip_driver(LIB_MECHANIZE, """
     The `webdav` method can only be used with a running ZServer.
     """)
-    @skip_driver(LIB_TRAVERSAL, """
-    The `webdav` method can only be used with a running ZServer.
-    """)
     @browsing
     def test_webdav_headers(self, browser):
         browser.webdav('get')

--- a/ftw/testbrowser/tests/test_webdav_requests.py
+++ b/ftw/testbrowser/tests/test_webdav_requests.py
@@ -1,24 +1,29 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.exceptions import ZServerRequired
+from ftw.testbrowser.core import LIB_MECHANIZE
+from ftw.testbrowser.exceptions import NoWebDAVSupport
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.testing import MECHANIZE_TESTING
-from ftw.testbrowser.testing import REQUESTS_TESTING
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.alldrivers import skip_driver
 
 
+@all_drivers
 class TestWebdavRequests(BrowserTestCase):
-    layer = REQUESTS_TESTING
 
+    @skip_driver(LIB_MECHANIZE, 'Mechanize does not support webdav.')
     @browsing
     def test_login_works(self, browser):
         browser.login().webdav('GET')
         self.assertTrue(plone.logged_in())
 
+    @skip_driver(LIB_MECHANIZE, 'Mechanize does not support webdav.')
     @browsing
     def test_options_request(self, browser):
         browser.webdav('OPTIONS')
         self.assertEquals('1,2', browser.headers.get('DAV'))
 
+    @skip_driver(LIB_MECHANIZE, 'Mechanize does not support webdav.')
     @browsing
     def test_propfind_request(self, browser):
         data = '\n'.join((
@@ -39,5 +44,5 @@ class TestNoZserverWebdavRequests(BrowserTestCase):
 
     @browsing
     def test_webdav_requires_zserver(self, browser):
-        with self.assertRaises(ZServerRequired):
+        with self.assertRaises(NoWebDAVSupport):
             browser.webdav('OPTIONS')


### PR DESCRIPTION
Make the ``.webdav()`` method support the current driver, so that it supports the traversal driver too.
The webdav method does not work with the mechanize driver since Mechanize does not support passing in the HTTP verb.