### PR TITLE
Log exceptions to stderr.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.23.3 (unreleased)
 -------------------
 
+- Log exceptions to stderr when they are not expected. [jone]
 - Standardize redirect loop detection: always throw a ``RedirectLoopException``. [jone]
 - Add traversal request driver. [jone]
 

--- a/ftw/testbrowser/drivers/requestsdriver.py
+++ b/ftw/testbrowser/drivers/requestsdriver.py
@@ -4,7 +4,6 @@ from ftw.testbrowser.exceptions import RedirectLoopException
 from ftw.testbrowser.exceptions import ZServerRequired
 from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.utils import copy_docs_from_interface
-from ftw.testbrowser.utils import verbose_logging
 from StringIO import StringIO
 from zope.interface import implements
 import requests
@@ -47,16 +46,15 @@ class RequestsDriver(object):
             headers['REFERER'] = referer_url
             headers['HTTP_REFERER'] = referer_url
 
-        with verbose_logging():
-            try:
-                self.response = self.requests_session.request(
-                    method, url, data=data, headers=headers)
-            except requests.exceptions.TooManyRedirects, exc:
-                raise RedirectLoopException(exc.request.url)
+        try:
+            self.response = self.requests_session.request(
+                method, url, data=data, headers=headers)
+        except requests.exceptions.TooManyRedirects, exc:
+            raise RedirectLoopException(exc.request.url)
 
-            return (self.response.status_code,
-                    self.response.reason,
-                    StringIO(self.response.content))
+        return (self.response.status_code,
+                self.response.reason,
+                StringIO(self.response.content))
 
     def reload(self):
         if self.previous_make_request is None:

--- a/ftw/testbrowser/log.py
+++ b/ftw/testbrowser/log.py
@@ -1,0 +1,47 @@
+from Products.SiteErrorLog import SiteErrorLog
+import logging
+import sys
+
+
+class ExceptionLogger(logging.Handler):
+    """When an exception happens while publishing an object, Zope will render
+    an error page (500).
+    For convenience we want the exception to be printed for a good developer
+    experience.
+    """
+
+    def __init__(self):
+        super(ExceptionLogger, self).__init__()
+        self.error_messages = []
+
+    def __enter__(self):
+        logging.root.addHandler(self)
+        self._ori_rate_period = SiteErrorLog._rate_restrict_period
+        # Make sure the rate limit of the error_log does not swallow our
+        # exceptions.
+        SiteErrorLog._rate_restrict_period = 0
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        SiteErrorLog._rate_restrict_period = self._ori_rate_period
+        logging.root.removeHandler(self)
+
+    def filter(self, record):
+        if record.name != 'Zope.SiteErrorLog':
+            return False
+
+        if not record.msg or not record.msg.strip():
+            return False
+
+        return True
+
+    def emit(self, record):
+        self.error_messages.append(record.msg)
+
+    def print_captured_exceptions(self):
+        if not self.error_messages:
+            return
+
+        print >>sys.stderr,  '\n'
+        for message in self.error_messages:
+            print >>sys.stderr, message

--- a/ftw/testbrowser/tests/helpers.py
+++ b/ftw/testbrowser/tests/helpers.py
@@ -1,7 +1,10 @@
+from contextlib import contextmanager
+from StringIO import StringIO
 from zope.component import getGlobalSiteManager
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserView
 import os.path
+import sys
 
 
 def asset(name, mode='r'):
@@ -28,3 +31,25 @@ class register_view(object):
 
     def get_sitemanager(self):
         return getGlobalSiteManager()
+
+
+@contextmanager
+def capture_streams(stdout=None, stderr=None):
+    ori_stdout = sys.stdout
+    ori_stderr = sys.stderr
+
+    assert not isinstance(ori_stdout, StringIO), 'stdout already captured'
+    assert not isinstance(ori_stderr, StringIO), 'stderr already captured'
+
+    if stdout is not None:
+        sys.stdout = stdout
+    if stderr is not None:
+        sys.stderr = stderr
+
+    try:
+        yield
+    finally:
+        if stdout is not None:
+            sys.stdout = ori_stdout
+        if stderr is not None:
+            sys.stderr = ori_stderr

--- a/ftw/testbrowser/tests/test_log.py
+++ b/ftw/testbrowser/tests/test_log.py
@@ -1,0 +1,54 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import HTTPError
+from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import capture_streams
+from ftw.testbrowser.tests.helpers import register_view
+from StringIO import StringIO
+from zope.publisher.browser import BrowserView
+
+
+@all_drivers
+class TestExceptionLogger(BrowserTestCase):
+
+    @browsing
+    def test_exceptions_are_printed_to_stderr(self, browser):
+        class FailingView(BrowserView):
+            def __call__(self):
+                raise ValueError('The value is wrong.')
+
+        with register_view(FailingView, 'failing-view'):
+            stderr = StringIO()
+            with capture_streams(stderr=stderr):
+                with self.assertRaises(HTTPError):
+                    browser.open(view='failing-view')
+
+        output = stderr.getvalue().strip()
+        # The output starts with a random error_log id => strip it.
+        self.assertTrue(output, 'No output in stderr')
+        output = output.split(' ', 1)[1]
+        self.assertEquals(
+            '{}/failing-view\n'.format(self.portal.absolute_url()) +
+            'Traceback (innermost last):\n'
+            '  Module ZPublisher.Publish, line 138, in publish\n'
+            '  Module ZPublisher.mapply, line 77, in mapply\n'
+            '  Module ZPublisher.Publish, line 48, in call_object\n'
+            '  Module ftw.testbrowser.tests.test_log, line 18, in __call__\n'
+            'ValueError: The value is wrong.',
+            output)
+
+    @browsing
+    def test_no_exceptions_logged_when_errors_expected(self, browser):
+        class FailingView(BrowserView):
+            def __call__(self):
+                raise ValueError('The value is wrong.')
+
+        with register_view(FailingView, 'failing-view'):
+            stderr = StringIO()
+            with capture_streams(stderr=stderr):
+                with browser.expect_http_error():
+                    browser.open(view='failing-view')
+
+        self.assertEquals(
+            '', stderr.getvalue(),
+            'No errors should be logged when using expect_http_error')

--- a/ftw/testbrowser/utils.py
+++ b/ftw/testbrowser/utils.py
@@ -1,24 +1,11 @@
-from contextlib import contextmanager
 from ftw.testbrowser.parser import TestbrowserHTMLParser
 from zope.interface.declarations import implementedBy
-import logging
 import lxml
 import re
-import sys
 
 
 def normalize_spaces(text):
     return re.sub(r'[\s\xa0]{1,}', ' ', text).strip()
-
-
-@contextmanager
-def verbose_logging():
-    stdouthandler = logging.StreamHandler(sys.stdout)
-    logging.root.addHandler(stdouthandler)
-    try:
-        yield
-    finally:
-        logging.root.removeHandler(stdouthandler)
 
 
 def parse_html(html):


### PR DESCRIPTION
When developing with the testbrowser a developer should see the
traceback of exceptions happening while publishing (e.g. in the view).
Because of the error handling only a 500 response was rendered.

We used to have logging enabled in the requests driver.
But this was only for this driver and it was noisy because it did log
other log entries too.

The new implementation is no longer in the driver but in the browser
core and it prints all entries added to Plone error_log while the
request is performed.
Exceptions are not printed within an expect_http_error context manager.