### PR TITLE
Traversal driver: decode gzip encoded responses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.24.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Traversal driver: decode gzip encoded responses. [jone]
 
 
 1.24.1 (2017-06-19)

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -30,8 +30,7 @@ class BrowserTestCase(TestCase):
 
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, list(roles))
-        if self.transactions_enabled():
-            transaction.commit()
+        self.maybe_commit_transaction()
 
     def sync_transaction(self):
         """Especially with the requests driver we sometimes need to sync
@@ -40,3 +39,11 @@ class BrowserTestCase(TestCase):
         """
         if self.transactions_enabled():
             transaction.begin()
+
+    def maybe_commit_transaction(self):
+        """Commit the transaction when transactions are enabled, in order to
+        have a change made in the testing connection available in the next
+        request.
+        """
+        if self.transactions_enabled():
+            transaction.commit()


### PR DESCRIPTION
Let the traversal driver decode gzip encoded responses, as it can be produced with plone.app.caching in Plone.