### PR TITLE
Reimplement query info with QueryInfo class.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.24.4 (unreleased)
 -------------------
 
+- Reimplement internal query info with a QueryInfo class. [jone]
 - Add send_authenticator option for CSRF support. [jone]
 
 

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -19,6 +19,7 @@ from ftw.testbrowser.interfaces import IBrowser
 from ftw.testbrowser.log import ExceptionLogger
 from ftw.testbrowser.nodes import wrap_nodes
 from ftw.testbrowser.nodes import wrapped_nodes
+from ftw.testbrowser.queryinfo import QueryInfo
 from ftw.testbrowser.utils import normalize_spaces
 from ftw.testbrowser.utils import parse_html
 from lxml.cssselect import CSSSelector
@@ -542,7 +543,8 @@ class Browser(object):
         self.clear_request_header('Authorization')
         return self
 
-    def css(self, css_selector):
+    @QueryInfo.build
+    def css(self, css_selector, query_info):
         """Select one or more HTML nodes by using a *CSS* selector.
 
         :param css_selector: The CSS selector.
@@ -550,11 +552,11 @@ class Browser(object):
         :returns: Object containg matches.
         :rtype: :py:class:`ftw.testbrowser.nodes.Nodes`
         """
-        query_info = ('browser', 'css', css_selector)
         return self.xpath(CSSSelector(css_selector).path,
                           query_info=query_info)
 
-    def xpath(self, xpath_selector, query_info=None):
+    @QueryInfo.build
+    def xpath(self, xpath_selector, query_info):
         """Select one or more HTML nodes by using an *xpath* selector.
 
         :param xpath_selector: The xpath selector.
@@ -562,7 +564,6 @@ class Browser(object):
         :returns: Object containg matches.
         :rtype: :py:class:`ftw.testbrowser.nodes.Nodes`
         """
-        query_info = query_info or ('browser', 'xpath', xpath_selector)
         nsmap = self.document.getroot().nsmap
         return wrap_nodes(
             self.document.xpath(xpath_selector, namespaces=nsmap),
@@ -768,7 +769,8 @@ class Browser(object):
                       map(attrgetter('field_labels'),
                           self.forms.values()))
 
-    def click_on(self, text, within=None):
+    @QueryInfo.build
+    def click_on(self, text, within=None, query_info=None):
         """Find a link by its text and click on it.
 
         :param text: The text to be looked for.
@@ -782,7 +784,7 @@ class Browser(object):
         """
         node = self.find(text)
         if not node:
-            raise NoElementFound(query_info=(self, 'click_on', text))
+            raise NoElementFound(query_info)
 
         node.click()
         return self

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -50,8 +50,10 @@ class NoElementFound(BrowserException):
 
     def __init__(self, query_info=None):
         if query_info is not None:
-            message = ('Empty result set: {0}.{1}("{2}") '
-                       'did not match any nodes.'.format(*query_info))
+            message = '\n'.join(
+                ['Empty result set: {} did not match any nodes.'.format(
+                    query_info.render_call())]
+                 + query_info.get_hints())
             Exception.__init__(self, message)
         else:
             super(NoElementFound, self).__init__()

--- a/ftw/testbrowser/queryinfo.py
+++ b/ftw/testbrowser/queryinfo.py
@@ -1,0 +1,105 @@
+from functools import wraps
+import inspect
+
+
+class QueryInfo(object):
+    """A QueryInfo object holds information about which query was executed
+    in order to have better exception messages when content cannot be found.
+
+    For example, a QueryInfo object records a ``node.css('.foo')`` call so
+    that we can tell the user which expression did not match.
+    The QueryInfo object can be enriched with additional information.
+    """
+
+    def __init__(self, function, args, kwargs):
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
+        self.hints = []
+
+    @classmethod
+    def build(klass, function):
+        argspec = inspect.getargspec(function)
+        if 'query_info' not in argspec.args and not argspec.keywords:
+            raise NameError(
+                'QueryInfo.build wrapped functions must accept a'
+                ' query_info argument or arbitrary keyword'
+                ' arguments (**kwargs).')
+
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            if 'query_info' in kwargs:
+                pass
+            elif 'query_info' in argspec.args and  \
+                 len(args) > argspec.args.index('query_info'):
+                pass
+            else:
+                kwargs['query_info'] = klass(function, args[:], kwargs.copy())
+            return function(*args, **kwargs)
+        return wrapper
+
+    def render(self):
+        """Render the query info object with the function call and the hints.
+
+        :returns: The method call.
+        :rtype: string
+        """
+        return '\n'.join([self.render_call()] + self.hints)
+
+    def add_hint(self, text):
+        """Append a hint as text to the query info object.
+        When an error is rendered using the query info object, the hint
+        will be shown too.
+
+        :param text: The hint text.
+        :type text: string
+        """
+        self.hints.append(text)
+
+    def get_hints(self):
+        """Returns a list of hints.
+
+        :returns: List of current hints.
+        :rtype: list of string
+        """
+        return self.hints
+
+    def render_call(self):
+        """render the function call made to the wrapped function and return
+        the string with the context, the name of the function and the
+        arguments.
+
+        :returns: The method call.
+        :rtype: string
+        """
+        argument_names = inspect.getargspec(self.function).args
+        positional_arguments = list(self.args)
+        if argument_names[0] == 'self':
+            # we have an instance method
+            context = repr(positional_arguments.pop(0))
+
+        elif len(positional_arguments) > 0 \
+             and type(positional_arguments[0]) is type:
+            # we have a class method
+            context = positional_arguments.pop(0).__name__
+
+        else:
+            # we have a module function
+            context = inspect.getmodule(self.function).__name__.split('.')[-1]
+
+        keyword_names = []
+        keyword_values = []
+        keyword_order = argument_names + sorted(self.kwargs.keys())
+        for name, value in sorted(
+                self.kwargs.items(),
+                key=lambda item: keyword_order.index(item[0])):
+            keyword_names.append(name)
+            keyword_values.append(value)
+
+        return '{}.{}{}'.format(
+            context,
+            self.function.__name__,
+            inspect.formatargspec(
+                map(repr, positional_arguments) + keyword_names,
+                None, None,
+                keyword_values))

--- a/ftw/testbrowser/tests/test_exceptions.py
+++ b/ftw/testbrowser/tests/test_exceptions.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browser
 from ftw.testbrowser import exceptions
+from ftw.testbrowser.queryinfo import QueryInfo
 from unittest2 import TestCase
 
 
@@ -34,6 +35,15 @@ class TestBrowserExceptions(TestCase):
                 'field label', ['missing'], ['foo', 'bar', 'baz'])))
 
 
+class Foo(object):
+    def __repr__(self):
+        return u'<Foo>'
+
+    @QueryInfo.build
+    def method(self, one=None, two=None, three=None, four=None, query_info=None):
+        return query_info
+
+
 class TestNoElementFoundException(TestCase):
 
     def test_no_query_info(self):
@@ -42,16 +52,8 @@ class TestNoElementFoundException(TestCase):
             str(exceptions.NoElementFound()))
 
     def test_query_info_on_browser(self):
-        query_info = ('browser', 'css', '.the-link')
+        query_info = Foo().method(two='two', one=1)
         self.assertEqual(
-            'Empty result set: browser.css(".the-link") did not match any nodes.',
+            "Empty result set: <Foo>.method(one=1, two='two')"
+            ' did not match any nodes.',
             str(exceptions.NoElementFound(query_info)))
-
-    def test_query_info_on_node(self):
-        with browser:
-            browser.open_html('<html><body></body></html>')
-            query_info = (browser.css('body').first, 'xpath', '//div')
-            self.assertEqual(
-                'Empty result set: <NodeWrapper:body, >.xpath("//div") did not'
-                ' match any nodes.',
-                str(exceptions.NoElementFound(query_info)))

--- a/ftw/testbrowser/tests/test_nodes.py
+++ b/ftw/testbrowser/tests/test_nodes.py
@@ -107,7 +107,8 @@ class TestNodesResultSet(BrowserTestCase):
             browser.css('.not-existing-class').first
 
         self.assertEquals(
-            'Empty result set: browser.css(".not-existing-class") did not'
+            'Empty result set: <ftw.browser.core.Browser instance>'
+            '.css(\'.not-existing-class\') did not'
             ' match any nodes.',
             str(cm.exception))
 
@@ -118,7 +119,8 @@ class TestNodesResultSet(BrowserTestCase):
             browser.xpath('//some-node').first
 
         self.assertEquals(
-            'Empty result set: browser.xpath("//some-node") did not'
+            'Empty result set: <ftw.browser.core.Browser instance>'
+            ".xpath('//some-node') did not"
             ' match any nodes.',
             str(cm.exception))
 
@@ -130,7 +132,7 @@ class TestNodesResultSet(BrowserTestCase):
             content.css('div.missing').first
 
         self.assertEquals(
-            'Empty result set: <NodeWrapper:div, id="content">.css("div.missing")'
+            'Empty result set: <NodeWrapper:div, id="content">.css(\'div.missing\')'
             ' did not match any nodes.',
             str(cm.exception))
 
@@ -142,7 +144,7 @@ class TestNodesResultSet(BrowserTestCase):
             content.xpath('//table').first
 
         self.assertEquals(
-            'Empty result set: <NodeWrapper:div, id="content">.xpath("//table")'
+            'Empty result set: <NodeWrapper:div, id="content">.xpath(\'//table\')'
             ' did not match any nodes.',
             str(cm.exception))
 
@@ -155,7 +157,7 @@ class TestNodesResultSet(BrowserTestCase):
 
         self.assertEquals(
             'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
-            '.css("div.missing") did not match any nodes.',
+            '.css(\'div.missing\') did not match any nodes.',
             str(cm.exception))
 
     @browsing
@@ -167,7 +169,7 @@ class TestNodesResultSet(BrowserTestCase):
 
         self.assertEquals(
             'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
-            '.xpath("//table") did not match any nodes.',
+            '.xpath(\'//table\') did not match any nodes.',
             str(cm.exception))
 
     @browsing
@@ -723,7 +725,7 @@ class TestLinkNode(BrowserTestCase):
 
         self.assertEquals(
             'Empty result set: <ftw.browser.core.Browser instance>'
-            '.click_on("Missing") did not match any nodes.',
+            ".click_on('Missing') did not match any nodes.",
             str(cm.exception))
 
 

--- a/ftw/testbrowser/tests/test_queryinfo.py
+++ b/ftw/testbrowser/tests/test_queryinfo.py
@@ -1,0 +1,89 @@
+from ftw.testbrowser import browser
+from ftw.testbrowser import exceptions
+from ftw.testbrowser.queryinfo import QueryInfo
+from unittest2 import TestCase
+
+
+class Foo(object):
+    def __repr__(self):
+        return u'<Foo>'
+
+    @QueryInfo.build
+    def method(self, one=None, two=None, three=None, four=None, query_info=None):
+        return query_info
+
+    @classmethod
+    @QueryInfo.build
+    def classmethod(klass, one=None, two=None, query_info=None):
+        return query_info
+
+    @QueryInfo.build
+    def arbitrary_args(self, one=None, *args, **kwargs):
+        return kwargs['query_info']
+
+    @QueryInfo.build
+    def nesting(self, one=None, **kwargs):
+        return self.method(one=one, **kwargs)
+
+
+@QueryInfo.build
+def bar(one=None, two=None, three=None, query_info=None):
+    return query_info
+
+
+@QueryInfo.build
+def show_hint(name=None, query_info=None):
+    query_info.add_hint('Valid names: Franzisika, Fritz')
+    return query_info
+
+
+class TestQueryInfo(TestCase):
+
+    def test_instance_method(self):
+        self.assertEquals(
+            '<Foo>.method()',
+            Foo().method().render_call())
+
+    def test_instance_method_with_positional_arguments(self):
+        self.assertEquals(
+            "<Foo>.method(1, 'two')",
+            Foo().method(1, 'two').render_call())
+
+    def test_instance_method_with_keyword_arguments(self):
+        # The order is always the order of the function definition.
+        # We do not know in which order the keyword arguments are
+        # ordered on call time.
+        self.assertEquals(
+            "<Foo>.method(one=1, two='two')",
+            Foo().method(two='two', one=1).render_call())
+
+    def test_instance_method_with_mixed_arguments(self):
+        self.assertEquals(
+            "<Foo>.method(1, 'two', four=[0, 1, 2, 3])",
+            Foo().method(1, 'two', four=range(4)).render_call())
+
+    def test_arbitrary_args(self):
+        self.assertEquals(
+            "<Foo>.arbitrary_args(1, 2, foo='Foo')",
+            Foo().arbitrary_args(1, 2, foo='Foo').render_call())
+
+    def test_class_method(self):
+        self.assertEquals(
+            "Foo.classmethod(1, two='two')",
+            Foo.classmethod(1, two='two').render_call())
+
+    def test_nesting_method_keeps_first_queryinfo(self):
+        self.assertEquals(
+            "<Foo>.nesting(one=1, two='two')",
+            Foo().nesting(one=1, two='two').render_call())
+
+    def test_module_function_with_arguments(self):
+        self.assertEquals(
+            "test_queryinfo.bar(1, three='three')",
+            bar(1, three='three').render_call())
+
+    def test_render_with_hint(self):
+        self.assertEquals(
+            "test_queryinfo.show_hint('Hans')\n"
+            'Valid names: Franzisika, Fritz',
+            show_hint('Hans').render())


### PR DESCRIPTION
A query info is created when using the testbrowser for finding things. It helps to render a meaningful error message when something cannot be found.

The goal of the refactoring was to support multiple arguments as well as additional hints. This is especially usful when building page objects.