### PR TITLE
Datagridfield widget: support cell-filling by other widgets.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.26.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Datagridfield widget: support cell-filling by other widgets. [jone]
 
 1.26.0 (2017-07-27)
 -------------------

--- a/ftw/testbrowser/widgets/autocomplete.py
+++ b/ftw/testbrowser/widgets/autocomplete.py
@@ -16,6 +16,13 @@ class AutocompleteWidget(PloneWidget):
 
         return len(node.css('div.autocompleteInputWidget')) > 0
 
+    @classmethod
+    def find_widget_in_datagrid_cell(kls, cell):
+        if len(cell.css('div.autocompleteInputWidget')) > 0:
+            return kls(cell, cell.browser)
+        else:
+            return None
+
     def fill(self, values):
         """Fill the autocomplete value with a key from the vocabulary.
         For content tree widgets, the value may be a Plone object which
@@ -30,7 +37,13 @@ class AutocompleteWidget(PloneWidget):
         values = self._resolve_objects_to_path(values)
 
         container = self.css('div.autocompleteInputWidget').first
-        fieldname = '%s:list' % self.fieldname
+
+        if self.fieldname is None:
+            # We are in a datagrid field and self is not a div.field
+            fieldname = (container.css('[name$="empty-marker"]').first
+                         .attrib.get('name').replace('-empty-marker', ''))
+        else:
+            fieldname = '%s:list' % self.fieldname
 
         # remove currently selected values
         for span in container.css('span.option'):

--- a/ftw/testbrowser/widgets/base.py
+++ b/ftw/testbrowser/widgets/base.py
@@ -18,6 +18,17 @@ class PloneWidget(NodeWrapper):
     def match(node):
         return node.tag == 'div' and 'field' in node.classes
 
+    @classmethod
+    def find_widget_in_datagrid_cell(kls, cell):
+        """Find the widget within a datagrid field cell.
+
+        :param cell: The datagrid field cell.
+        :type cell: :py:class:`ftw.testbrowser.nodes.NodeWrapper`.
+        :return: The widget instance or ``None``.
+        :rtype: :py:class:`ftw.testbrowser.widgets.base.PloneWidget`.
+        """
+        return None
+
     def fill(self, value):
         """Subclassing widgets should implement this method or provide a name
         property for form filling to work.


### PR DESCRIPTION
Widgets now can implement a method ``find_widget_in_datagrid_cell``. The method may return a widget instance for a cell object. This makes it easy to inject datagrid support for any widgets.