### PR TITLE
Add InsufficientPrivileges exception.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.25.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Feature: raise ``InsufficientPrivileges`` when a Plone request
+  causes a insufficient privileges problem. [jone]
 
 1.25.0 (2017-07-04)
 -------------------

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -539,6 +539,13 @@ When the response has a status code of `4xx`, a
 when the status code is `5xx`, a
 :py:class:`ftw.testbrowser.exceptions.HTTPServerError` is raised.
 
+When the requests is sent to a Plone CMS and causes an "insufficient privileges"
+result, a
+:py:class:`ftw.testbrowser.exceptions.InsufficientPrivileges` is raised.
+The exception is raised for anonymous users (rendering the login form) as well
+as for logged in users (rendering the "Insufficient Privileges" page).
+
+
 
 Disabling HTTP exceptions
 -------------------------

--- a/ftw/testbrowser/__init__.py
+++ b/ftw/testbrowser/__init__.py
@@ -5,9 +5,10 @@ from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.drivers.layers import DefaultDriverFixture
 from ftw.testbrowser.exceptions import HTTPClientError
 from ftw.testbrowser.exceptions import HTTPServerError
+from ftw.testbrowser.exceptions import InsufficientPrivileges
 
 
-HTTPClientError, HTTPServerError  # noqa
+HTTPClientError, HTTPServerError, InsufficientPrivileges  # noqa
 
 
 #: The singleton browser instance acting as default browser.

--- a/ftw/testbrowser/exceptions.py
+++ b/ftw/testbrowser/exceptions.py
@@ -147,3 +147,21 @@ class HTTPServerError(HTTPError):
     :ivar status_reason: The status reason, e.g. ``"Internal Server Error"``
     :type status_reason: ``string``
     """
+
+class InsufficientPrivileges(HTTPClientError):
+    """This exception is raised when Plone responds that the user has
+    insufficient privileges for performing that request.
+
+    Plone redirects the user to a "require_login" script when the user has
+    not enough privileges (causing an internal Unauthorized exception to be
+    raised).
+
+    When a user is logged in, the "require_login" script will render a page
+    with the title "Insufficient Privileges".
+    For anonymous users, the login form is rendered.
+    Both cases cause the testbrowser to raise an InsufficientPrivileges
+    exception.
+
+    This exception can be disabled with by disabling the ``raise_http_errors``
+    option.
+    """

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -2,6 +2,7 @@ from ftw.testbrowser import Browser
 from ftw.testbrowser import browsing
 from ftw.testbrowser import HTTPClientError
 from ftw.testbrowser import HTTPServerError
+from ftw.testbrowser import InsufficientPrivileges
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.pages import plone
@@ -146,6 +147,27 @@ class TestBrowserCore(BrowserTestCase):
             browser.raise_http_errors = False
             with capture_streams(stderr=StringIO()):
                 browser.reload()
+
+    @browsing
+    def test_raises_insufficient_privileges_for_anonymous(self, browser):
+        """When an anonymous user accesses a protected content, Plone will
+        redirect to a "require_login" script, rendering a login form.
+        By default, the ftw.testbrowser should raise an InsufficientPrivileges
+        exception in this case.
+        """
+        with self.assertRaises(InsufficientPrivileges):
+            browser.open(view='plone_control_panel')
+
+    @browsing
+    def test_raises_insufficient_privileges_for_logged_in_user(self, browser):
+        """When an logged in user accesses a protected content, Plone will
+        redirect to a "require_login" script, rendering "Insufficient Privileges".
+        By default, the ftw.testbrowser should raise an InsufficientPrivileges
+        exception in this case.
+        """
+        browser.login()
+        with self.assertRaises(InsufficientPrivileges):
+            browser.open(view='plone_control_panel')
 
     @browsing
     def test_expect_http_error(self, browser):


### PR DESCRIPTION
TheWhen the requests is sent to a Plone CMS and causes an "insufficient privileges" result, a ``ftw.testbrowser.exceptions.InsufficientPrivileges`` is raised.

The exception is raised for anonymous users (rendering the login form) as well as for logged in users (rendering the "Insufficient Privileges" page).

The goal is to early abort and report problems, so that debugging permission problems is easier.