### PR TITLE
Fix context manager / reset behavior.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.26.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Disallow using browser as nested context manager. [jone]
+- Fix reset behavior while used in context manager. [jone]
 
 1.26.0 (2017-07-27)
 -------------------

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -173,12 +173,12 @@ Logout and login a different user:
 .. code:: py
 
     browser.login(username='john.doe', password='secret').open()
-    browser.reset()
+    browser.logout()
     browser.login().open()
 
 
 .. seealso:: :py:func:`ftw.testbrowser.core.Browser.login`,
-             :py:func:`ftw.testbrowser.core.Browser.reset`
+             :py:func:`ftw.testbrowser.core.Browser.logout`
 
 
 Finding elements

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import Browser
+from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
 from ftw.testbrowser import HTTPClientError
 from ftw.testbrowser import HTTPServerError
@@ -316,6 +317,20 @@ class TestBrowserCore(BrowserTestCase):
     def test_opening_preserves_global_request(self, browser):
         browser.open()
         self.assertIsNotNone(getRequest())
+
+    def test_reset_does_not_break_context_manager(self):
+        with browser(self.layer['app']):
+            browser.open()
+            browser.reset()
+            browser.open()
+
+    def test_nesting_context_manager_not_allowed(self):
+        with browser:
+            with self.assertRaises(ValueError) as cm:
+                with browser:
+                    pass
+            self.assertEquals('Nesting browser context manager is not allowed.',
+                              str(cm.exception))
 
     def assert_starts_with(self, start, contents):
         self.assertTrue(


### PR DESCRIPTION
Fix reset when used within the context manager: it should not reset the context manager. In order to detect if we are in a context manager, an internal context manager flag is added. In order for the flag to work correctly, nested context managers must be disallowed.

Closes #16