### PR TITLE
Use current pages default `#form` in erroneous_fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,16 +14,19 @@ Changelog
 - Disallow using browser as nested context manager. [jone]
 - Fix reset behavior while used in context manager. [jone]
 
+
 1.26.1 (2017-07-31)
 -------------------
 
 - Datagridfield widget: support cell-filling by other widgets. [jone]
+
 
 1.26.0 (2017-07-27)
 -------------------
 
 - Feature: raise ``InsufficientPrivileges`` when a Plone request
   causes a insufficient privileges problem. [jone]
+
 
 1.25.0 (2017-07-04)
 -------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.26.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use current page's default `#form` in `erroneous_fields`. [deiferni]
 
 
 1.26.2 (2017-08-14)

--- a/ftw/testbrowser/pages/z3cform.py
+++ b/ftw/testbrowser/pages/z3cform.py
@@ -1,16 +1,26 @@
+from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.utils import normalize_spaces
 
 
-def erroneous_fields(form):
+def erroneous_fields(form=None):
     """Returns a mapping of erroneous fields (key is label or name of
     the field) to a list of error messages for the fields on the form
     passed as argument.
 
-    :param form: The form node to check for errors.
+    :param form: The form node to check for errors. Defaults to the form with
+      the id `#form` in the default browser.
     :type form: :py:class:`ftw.testbrowser.form.Form`
     :returns: A dict of erroneous fields with error messages.
     :rtype: dict
     """
+    if form is None:
+        form = default_browser.forms.get('form')
+        if form is None:
+            available_forms = default_browser.forms.keys()
+            raise ValueError(
+                'Could not find the default `#form` on the current page, '
+                'please provide a valid form. Available forms are: {0}'
+                .format(available_forms))
 
     result = {}
     for input in form.inputs:

--- a/ftw/testbrowser/tests/test_pages_z3cform.py
+++ b/ftw/testbrowser/tests/test_pages_z3cform.py
@@ -9,7 +9,7 @@ from ftw.testbrowser.tests.alldrivers import all_drivers
 class TestZ3cformPageObject(BrowserTestCase):
 
     @browsing
-    def test_erroneous_fields(self, browser):
+    def test_erroneous_fields_default_form(self, browser):
         self.grant('Manager')
 
         browser.login().open()
@@ -18,6 +18,23 @@ class TestZ3cformPageObject(BrowserTestCase):
 
         self.assertEquals(browser.previous_url, browser.url)
 
-        form = browser.css('form#form').first
         self.assertEquals({u'Title': ['Required input is missing.']},
-                          z3cform.erroneous_fields(form))
+                          z3cform.erroneous_fields())
+
+    @browsing
+    def test_erroneous_fields_missing_default_form(self, browser):
+        browser.visit(view='test-form')
+        with self.assertRaises(ValueError) as cm:
+            z3cform.erroneous_fields()
+
+        self.assertEqual(
+            "Could not find the default `#form` on the current page, please "
+            "provide a valid form. Available forms are: "
+            "['test-form', 'searchGadget_form', 'test-get-form']",
+            cm.exception.message)
+
+    @browsing
+    def test_erroneous_fields_with_custom_form(self, browser):
+        browser.visit(view='test-form')
+        self.assertEqual(
+            {}, z3cform.erroneous_fields(browser.forms['test-form']))


### PR DESCRIPTION
Use the form identified by the id `#form` as the default form for the `erroneous_fields` page. For plone tests it can be assumed that often the form under test is a content-type related form. Both
add and edit forms of plone content-types seem to use the id `#form`. Thus this PR provide this shortcut.