### PR TITLE
Make plone.protect import optional.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.26.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Make ``plone.protect`` import optional so that ``ftw.testbrowser``
+  works without ``plone.protect``. [jone]
 
 1.26.2 (2017-08-14)
 -------------------

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -27,7 +27,6 @@ from lxml.cssselect import CSSSelector
 from OFS.interfaces import IItem
 from operator import attrgetter
 from operator import methodcaller
-from plone.protect import createToken
 from StringIO import StringIO
 from zope.component.hooks import getSite
 from zope.interface import implements
@@ -239,6 +238,8 @@ class Browser(object):
         :param send_authenticator: When true, a ``plone.protect`` CSRF
           authenticator token is sent as if we would submit a prepared form.
           When this flag option is used, the request may be sent as ``POST``.
+          The code using the testbrowser with the ``send_authenticator`` option
+          must make sure that ``plone.protect`` is installed.
         :type send_authenticator: Boolean (Default ``False``)
 
         .. seealso:: :py:func:`visit`
@@ -253,6 +254,10 @@ class Browser(object):
             if data is None:
                 data = {}
 
+            # plone.protect may not be installed: the import is inline in
+            # order to only require plone.protect when the send_authenticator
+            # option is actually used.
+            from plone.protect import createToken
             data['_authenticator'] = createToken()
 
         if method is None and data is None:


### PR DESCRIPTION
ftw.testbrowser should avoid dependencies on Plone packages, so that it can be used outside of a Plone environment.

The send_authenticator added in ftw.testbrowser 1.25.0 introduced a plone.protect import, causing the testbrowser to no longer work without plone.protect.

By moving the plone.protect import from the module head to the code send_authenticator code block, plone.protect is only imported when it is actually used. The package using ftw.testbrowser with the send_authenticator option is responsible to make sure that plone.protect is correctly installed.

Closes #71 