### PR TITLE
Improve multi browser support in standard page objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.26.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Improve multi browser support in standard page objects. [jone]
 
 1.26.3 (2017-09-11)
 -------------------

--- a/docs/source/api_pages.rst
+++ b/docs/source/api_pages.rst
@@ -46,3 +46,10 @@ z3cform page object
 
 .. automodule:: ftw.testbrowser.pages.z3cform
    :members:
+
+
+Folder contents page object
+===========================
+
+.. automodule:: ftw.testbrowser.pages.folder_contents
+   :members:

--- a/ftw/testbrowser/pages/folder_contents.py
+++ b/ftw/testbrowser/pages/folder_contents.py
@@ -7,6 +7,7 @@ def titles(browser=default_browser):
     """Returns all titles of the objects listed on the folder contents view.
 
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: Titles of objects
     :rtype: list of strings
     """
@@ -17,6 +18,7 @@ def title_cells(browser=default_browser):
     """Returns all the cell of the title column.
 
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: Cells of the title column.
     :rtype: list of cell objects
     """
@@ -31,38 +33,52 @@ def dicts(browser=default_browser, **kwargs):
     It removes the select-all header row.
 
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: List of rows, represented as dicts.
     :rtype: list of dicts
     """
     return table(browser=browser).dicts(head_offset=1, **kwargs)
 
 
-def select(*objects):
+def select(*objects, **kwargs):
     """Selects the checkboxes on one or more rows by objects.
 
-    :param titles: List of Plone objects to select.
+    :param objects: List of Plone objects to select.
+    :type objects: list of Plone objects
+    :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     """
-    select_rows(map(row_by_object, objects))
+    browser = kwargs.pop('browser', default_browser)
+    assert not kwargs, 'Invalid keyword arguments: {!r}'.format(kwargs)
+    select_rows([row_by_object(obj, browser=browser) for obj in objects])
 
 
-def select_by_title(*titles):
+def select_by_title(*titles, **kwargs):
     """Selects the checkboxes on one or more rows by the title of
     the objects.
 
     :param titles: Titles for objects to select.
     :type titles: list of strings
+    :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     """
-    select_rows(map(row_by_title, titles))
+    browser = kwargs.pop('browser', default_browser)
+    assert not kwargs, 'Invalid keyword arguments: {!r}'.format(kwargs)
+    select_rows([row_by_title(title, browser=browser) for title in titles])
 
 
-def select_by_path(*paths):
+def select_by_path(*paths, **kwargs):
     """Selects the checkboxes on one or more rows by the path of
     the objects.
 
-    :param titles: Paths for objects to select.
-    :type titles: list of strings
+    :param paths: Paths for objects to select.
+    :type paths: list of strings
+    :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     """
-    select_rows(map(row_by_path, paths))
+    browser = kwargs.pop('browser', default_browser)
+    assert not kwargs, 'Invalid keyword arguments: {!r}'.format(kwargs)
+    select_rows([row_by_path(path, browser=browser) for path in paths])
 
 
 def select_rows(rows):
@@ -82,6 +98,7 @@ def row_by_title(title, browser=default_browser):
     :param title: The title of the object.
     :type title: string
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: The row node.
     :rtype: :py:class:`ftw.testbrowser.table.TableRow`
     """
@@ -105,7 +122,9 @@ def row_by_object(obj, browser=default_browser):
     """Returns the row for an object.
 
     :param obj: The object to look for.
+    :type obj: A plone object.
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: The row node.
     :rtype: :py:class:`ftw.testbrowser.table.TableRow`
     """
@@ -116,9 +135,10 @@ def row_by_object(obj, browser=default_browser):
 def row_by_path(path, browser=default_browser):
     """Returns the row for an object by its path.
 
-    :param obj: The path of the object to look for.
-    :type obj: string
+    :param path: The path of the object to look for.
+    :type path: string
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: The row node.
     :rtype: :py:class:`ftw.testbrowser.table.TableRow`
     """
@@ -136,6 +156,7 @@ def table(browser=default_browser):
     """The folder contents table node.
 
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: The folder contents table node.
     :rtype: :py:class:`ftw.testbrowser.table.Table`
     """
@@ -147,6 +168,7 @@ def form(browser=default_browser):
     """The folder contents form node.
 
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: The folder contents form node.
     :rtype: :py:class:`ftw.testbrowser.form.Form`
     """
@@ -157,6 +179,7 @@ def selected_paths(browser=default_browser):
     """Returns the paths of checkboxes currently selected.
 
     :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: paths of selected checkboxes
     :rtype: tuple of strings
     """
@@ -164,6 +187,13 @@ def selected_paths(browser=default_browser):
 
 
 def rows_by_path(browser=default_browser):
+    """Return a mapping of paths to row objects.
+
+    :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
+    :returns: mapping of row paths to row nodes.
+    :rtype: dict
+    """
     result = {}
     for row in table(browser=browser).body_rows:
         path = row.css('input[type=checkbox]').first.attrib['value']
@@ -172,6 +202,15 @@ def rows_by_path(browser=default_browser):
 
 
 def column_title_by_name(name, browser=default_browser):
+    """Find a column title by the name of the column.
+
+    :param name: Name of the column
+    :type name: str
+    :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
+    :returns: Title of the column
+    :rtype: str
+    """
     mapping = dict(map(lambda th: (th.attrib.get('id'), th.text),
                        table(browser=browser).head_rows.css('th.column')))
     return mapping['foldercontents-{0}-column'.format(name)]

--- a/ftw/testbrowser/pages/statusmessages.py
+++ b/ftw/testbrowser/pages/statusmessages.py
@@ -46,7 +46,7 @@ def error_messages(browser=default_browser):
     return messages(browser=browser)['error']
 
 
-def as_string(filter_=None):
+def as_string(filter_=None, browser=default_browser):
     """All status messages as string instead of dict, so that it can be used
     for formatting assertion errors.
     Pass a type ("info", "warning" or "error") for filter_ing the messages.
@@ -58,7 +58,7 @@ def as_string(filter_=None):
         filter_ = (filter_,)
 
     result = []
-    for msg_type, msg_texts in sorted(messages().items()):
+    for msg_type, msg_texts in sorted(messages(browser=browser).items()):
         if msg_type not in filter_:
             continue
 
@@ -73,7 +73,7 @@ def assert_message(text, browser=default_browser):
     all_messages = reduce(list.__add__, messages(browser=browser).values())
     if text not in all_messages:
         raise AssertionError('No status message "%s". Current messages: %s' % (
-                text, as_string()))
+                text, as_string(browser=browser)))
     return True
 
 
@@ -82,7 +82,8 @@ def assert_no_messages(browser=default_browser):
     """
     all_messages = reduce(list.__add__, messages(browser=browser).values())
     if len(all_messages) > 0:
-        raise AssertionError('Unexpected status messages: %s' % as_string())
+        raise AssertionError('Unexpected status messages: {}'.format(
+            as_string(browser=browser)))
     return True
 
 
@@ -91,5 +92,5 @@ def assert_no_error_messages(browser=default_browser):
     """
     if len(error_messages(browser=browser)) > 0:
         raise AssertionError('Unexpected "error" status messages: %s' % (
-                as_string('error')))
+                as_string('error', browser=browser)))
     return True

--- a/ftw/testbrowser/pages/z3cform.py
+++ b/ftw/testbrowser/pages/z3cform.py
@@ -1,13 +1,16 @@
+from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.utils import normalize_spaces
 
 
-def erroneous_fields(form):
+def erroneous_fields(form, browser=default_browser):
     """Returns a mapping of erroneous fields (key is label or name of
     the field) to a list of error messages for the fields on the form
     passed as argument.
 
     :param form: The form node to check for errors.
     :type form: :py:class:`ftw.testbrowser.form.Form`
+    :param browser: A browser instance. (Default: global browser)
+    :type browser: :py:class:`ftw.testbrowser.core.Browser`
     :returns: A dict of erroneous fields with error messages.
     :rtype: dict
     """

--- a/ftw/testbrowser/tests/helpers.py
+++ b/ftw/testbrowser/tests/helpers.py
@@ -1,4 +1,6 @@
 from contextlib import contextmanager
+from ftw.testbrowser import browsing
+from functools import wraps
 from StringIO import StringIO
 from zope.component import getGlobalSiteManager
 from zope.interface import Interface
@@ -53,3 +55,23 @@ def capture_streams(stdout=None, stderr=None):
             sys.stdout = ori_stdout
         if stderr is not None:
             sys.stderr = ori_stderr
+
+
+def nondefault_browsing(func):
+    """The @nondefault_browsing decorator is similar to the @browsing
+    decorator, but it creates a cloned browser instance instead of using
+    the default browser.
+
+    This decorator is used for testing page objects.
+    Page objects allow to pass in the browser instance in order to support
+    multiple browser.
+    By using a non-default browser and passing in the browser object, we make
+    sure that the page objects actually use the passed in browser instace
+    recursively.
+    """
+    @wraps(func)
+    @browsing
+    def wrapper(self, browser):
+        with browser.clone() as cloned_browser:
+            return func(self, cloned_browser)
+    return wrapper

--- a/ftw/testbrowser/tests/test_pages_dexterity.py
+++ b/ftw/testbrowser/tests/test_pages_dexterity.py
@@ -1,21 +1,21 @@
-from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import dexterity
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import nondefault_browsing
 
 
 @all_drivers
 class TestDexterityPageObject(BrowserTestCase):
 
-    @browsing
+    @nondefault_browsing
     def test_erroneous_fields(self, browser):
         self.grant('Manager')
 
         browser.login().open()
-        factoriesmenu.add('Folder')
+        factoriesmenu.add('Folder', browser=browser)
         browser.find('Save').click()
 
         self.assertEquals(browser.previous_url, browser.url)
         self.assertEquals({u'Title': ['Required input is missing.']},
-                          dexterity.erroneous_fields())
+                          dexterity.erroneous_fields(browser=browser))

--- a/ftw/testbrowser/tests/test_pages_editbar.py
+++ b/ftw/testbrowser/tests/test_pages_editbar.py
@@ -1,124 +1,129 @@
-from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import nondefault_browsing
 
 
 @all_drivers
 class TestEditBar(BrowserTestCase):
 
-    @browsing
+    @nondefault_browsing
     def test_visible(self, browser):
         browser.open()
-        self.assertFalse(editbar.visible())
+        self.assertFalse(editbar.visible(browser=browser))
 
         self.grant('Manager')
         browser.login().open()
-        self.assertTrue(editbar.visible())
+        self.assertTrue(editbar.visible(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_contentviews(self, browser):
         self.grant('Manager')
         browser.login().open()
-        self.assertEquals(['Contents', 'View', 'Sharing'], editbar.contentviews())
+        self.assertEquals(['Contents', 'View', 'Sharing'],
+                          editbar.contentviews(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_contentview(self, browser):
         self.grant('Manager')
         browser.login().open()
-        link = editbar.contentview('Contents')
+        link = editbar.contentview('Contents', browser=browser)
         self.assertEquals('a', link.tag)
         self.assertDictContainsSubset(
             {'href': self.portal.absolute_url() + '/folder_contents'},
             link.attrib)
 
-    @browsing
+    @nondefault_browsing
     def test_contentview_not_found(self, browser):
         self.grant('Manager')
         browser.login().open()
         with self.assertRaises(NoElementFound) as cm:
-            editbar.contentview('Nonexisting View')
+            editbar.contentview('Nonexisting View', browser=browser)
 
         self.assertEquals(
             "Empty result set:"
-            " editbar.contentview('Nonexisting View') did not match any nodes."
+            " editbar.contentview('Nonexisting View',"
+            " browser=<ftw.browser.core.Browser instance>) did not match any nodes."
             "\nVisible content views: ['Contents', 'View', 'Sharing'].",
             str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_menus(self, browser):
         self.grant('Manager')
         browser.login().open()
-        self.assertEquals([u'Add new', 'Display'], editbar.menus())
+        self.assertEquals([u'Add new', 'Display'], editbar.menus(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_menu(self, browser):
         self.grant('Manager')
         browser.login().open()
-        self.assertIn('actionMenu', editbar.menu('Display').classes)
-        self.assertIn('actionMenu', editbar.menu('Add new').classes)
+        self.assertIn('actionMenu', editbar.menu('Display', browser=browser).classes)
+        self.assertIn('actionMenu', editbar.menu('Add new', browser=browser).classes)
 
-    @browsing
+    @nondefault_browsing
     def test_menu_not_found(self, browser):
         self.grant('Manager')
         browser.login().open()
         with self.assertRaises(NoElementFound) as cm:
-            editbar.menu('Shapes')
+            editbar.menu('Shapes', browser=browser)
 
         self.assertEquals(
-            "Empty result set: editbar.menu('Shapes') did not match any nodes."
+            "Empty result set: editbar.menu('Shapes',"
+            " browser=<ftw.browser.core.Browser instance>) did not match any nodes."
             "\nVisible menus: [u'Add new', u'Display'].",
             str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_menu_options(self, browser):
         self.grant('Manager')
         browser.login().open()
-        self.assertIn('Summary view', editbar.menu_options('Display'))
+        self.assertIn('Summary view', editbar.menu_options('Display', browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_menu_option(self, browser):
         self.grant('Manager')
         browser.login().open()
-        link = editbar.menu_option('Display', 'Summary view')
+        link = editbar.menu_option('Display', 'Summary view', browser=browser)
         self.assertEquals('plone-contentmenu-display-summary_view',
                           link.attrib.get('id'))
         self.assertEquals('a', link.tag)
 
-    @browsing
+    @nondefault_browsing
     def test_menu_option_not_found(self, browser):
         self.grant('Manager')
         browser.login().open()
         with self.assertRaises(NoElementFound) as cm:
-            editbar.menu_option('Add new', 'Dog')
+            editbar.menu_option('Add new', 'Dog', browser=browser)
 
         self.assertEquals(
-            "Empty result set: editbar.menu_option('Add new', 'Dog')"
+            "Empty result set: editbar.menu_option('Add new', 'Dog',"
+            " browser=<ftw.browser.core.Browser instance>)"
             " did not match any nodes."
             "\nOptions in menu 'Add new': ['Collection', 'DXType', 'Event',"
             " 'File', 'Folder', 'Image', 'Link', 'News Item', 'Page']",
             str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_menu_option_menu_not_found(self, browser):
         self.grant('Manager')
         browser.login().open()
         with self.assertRaises(NoElementFound) as cm:
-            editbar.menu_option('Shapes', 'Square')
+            editbar.menu_option('Shapes', 'Square', browser=browser)
 
         self.assertEquals(
-            "Empty result set: editbar.menu_option('Shapes', 'Square')"
+            "Empty result set: editbar.menu_option('Shapes', 'Square',"
+            " browser=<ftw.browser.core.Browser instance>)"
             " did not match any nodes."
             "\nVisible menus: [u'Add new', u'Display'].",
             str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_container(self, browser):
         browser.open()
         with self.assertRaises(NoElementFound):
-            editbar.container()
+            editbar.container(browser=browser)
 
         self.grant('Manager')
         browser.login().open()
-        self.assertTrue(editbar.container())
+        self.assertTrue(editbar.container(browser=browser))

--- a/ftw/testbrowser/tests/test_pages_factoriesmenu.py
+++ b/ftw/testbrowser/tests/test_pages_factoriesmenu.py
@@ -1,65 +1,65 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import nondefault_browsing
 
 
 @all_drivers
 class TestFactoriesMenu(BrowserTestCase):
 
-    @browsing
+    @nondefault_browsing
     def test_factoriesmenu_visible(self, browser):
         self.grant('Manager')
         browser.open()
-        self.assertFalse(factoriesmenu.visible())
+        self.assertFalse(factoriesmenu.visible(browser=browser))
         browser.login().open()
-        self.assertTrue(factoriesmenu.visible())
+        self.assertTrue(factoriesmenu.visible(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_addable_types(self, browser):
         self.grant('Manager')
         browser.login().open()
-        self.assertIn('Folder', factoriesmenu.addable_types())
+        self.assertIn('Folder', factoriesmenu.addable_types(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_addable_types_raises_when_menu_not_visible(self, browser):
         browser.open()
         with self.assertRaises(ValueError) as cm:
-            factoriesmenu.addable_types()
+            factoriesmenu.addable_types(browser=browser)
 
         self.assertEquals('Factories menu is not visible.', str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_adding_content(self, browser):
         self.grant('Manager')
         browser.login().open()
-        factoriesmenu.add('Folder')
+        factoriesmenu.add('Folder', browser=browser)
         self.assertEquals(self.portal.portal_url() + '/++add++Folder', browser.url)
 
-    @browsing
+    @nondefault_browsing
     def test_adding_unallowed_or_missing_type(self, browser):
         self.grant('Manager')
         browser.login().open()
         with self.assertRaises(ValueError) as cm:
-            factoriesmenu.add('Unkown Type')
+            factoriesmenu.add('Unkown Type', browser=browser)
 
         self.assertTrue(
             str(cm.exception).startswith(
                 'The type "Unkown Type" is not addable. Addable types: '),
             str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_adding_fails_when_no_factoriesmenu_visible(self, browser):
         browser.open()
         with self.assertRaises(ValueError) as cm:
-            factoriesmenu.add('Folder')
+            factoriesmenu.add('Folder', browser=browser)
 
         self.assertEquals('Cannot add "Folder": no factories menu visible.',
                           str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_addable_types_works_with_restrictions_entry(self, browser):
         self.grant('Manager')
         # Regression:
@@ -68,4 +68,5 @@ class TestFactoriesMenu(BrowserTestCase):
         # This test verifies that this still works.
         folder = create(Builder('folder'))
         browser.login().visit(folder)
-        self.assertIn(u'Restrictions\u2026', factoriesmenu.addable_types())
+        self.assertIn(u'Restrictions\u2026',
+                      factoriesmenu.addable_types(browser=browser))

--- a/ftw/testbrowser/tests/test_pages_folder_contents.py
+++ b/ftw/testbrowser/tests/test_pages_folder_contents.py
@@ -1,10 +1,10 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import folder_contents
 from ftw.testbrowser.table import TableRow
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import nondefault_browsing
 
 
 @all_drivers
@@ -14,35 +14,36 @@ class TestFolderContents(BrowserTestCase):
         super(TestFolderContents, self).setUp()
         self.grant('Manager')
 
-    @browsing
+    @nondefault_browsing
     def test_titles(self, browser):
         create(Builder('page').titled(u'An exotic page'))
         browser.login().open(view='folder_contents')
-        self.assertEquals(['An exotic page'], folder_contents.titles())
+        self.assertEquals(['An exotic page'],
+                          folder_contents.titles(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_select__selects_from_objects(self, browser):
         foo = create(Builder('page').titled(u'Foo'))
         bar = create(Builder('page').titled(u'Bar'))
 
         browser.login().open(view='folder_contents')
-        folder_contents.select(foo, bar)
+        folder_contents.select(foo, bar, browser=browser)
         self.assertEquals(
             ('/plone/foo', '/plone/bar'),
-            folder_contents.selected_paths())
+            folder_contents.selected_paths(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_select_by_title(self, browser):
         create(Builder('page').titled(u'Foo'))
         create(Builder('page').titled(u'Bar'))
 
         browser.login().open(view='folder_contents')
-        folder_contents.select_by_title('Foo', 'Bar')
+        folder_contents.select_by_title('Foo', 'Bar', browser=browser)
         self.assertEquals(
             ('/plone/foo', '/plone/bar'),
-            folder_contents.selected_paths())
+            folder_contents.selected_paths(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_select_by_path(self, browser):
         foo = create(Builder('page').titled(u'Foo'))
         foo_path = '/'.join(foo.getPhysicalPath())
@@ -50,48 +51,50 @@ class TestFolderContents(BrowserTestCase):
         bar_path = '/'.join(bar.getPhysicalPath())
 
         browser.login().open(view='folder_contents')
-        folder_contents.select_by_path(foo_path, bar_path)
+        folder_contents.select_by_path(foo_path, bar_path, browser=browser)
         self.assertEquals(
             ('/plone/foo', '/plone/bar'),
-            folder_contents.selected_paths())
+            folder_contents.selected_paths(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_row_by_title(self, browser):
         create(Builder('page').titled(u'Foo'))
         browser.login().open(view='folder_contents')
 
         with self.assertRaises(ValueError) as cm:
-            folder_contents.row_by_title('Bar')
+            folder_contents.row_by_title('Bar', browser=browser)
         self.assertEquals('No row with title "Bar" found.',
                           str(cm.exception))
 
-        self.assertEquals(TableRow, type(folder_contents.row_by_title('Foo')))
+        self.assertEquals(TableRow,
+                          type(folder_contents.row_by_title('Foo', browser=browser)))
 
         create(Builder('page').titled(u'Foo'))
         browser.reload()
         with self.assertRaises(ValueError) as cm:
-            folder_contents.row_by_title('Foo')
+            folder_contents.row_by_title('Foo', browser=browser)
         self.assertEquals(
             'More than one row with title "Foo" found: ' +
             "['{0}/foo', '{0}/foo-1']".format(self.portal.portal_url()),
             str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_row_by_object(self, browser):
         obj = create(Builder('folder').titled(u'Foo'))
         subobj = create(Builder('page').titled(u'Bar').within(obj))
         browser.login().open(view='folder_contents')
 
-        self.assertEquals(TableRow, type(folder_contents.row_by_object(obj)))
+        self.assertEquals(TableRow,
+                          type(folder_contents.row_by_object(obj, browser=browser)))
 
         with self.assertRaises(ValueError) as cm:
-            folder_contents.row_by_object(subobj)
+            folder_contents.row_by_object(subobj, browser=browser)
         self.assertEquals(
             'The object with path "/plone/foo/bar" is not visible.'
             " Visible objects: ['/plone/foo']",
             str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_row_by_path(self, browser):
         obj = create(Builder('folder').titled(u'Foo'))
         subobj = create(Builder('page').titled(u'Bar').within(obj))
@@ -101,10 +104,10 @@ class TestFolderContents(BrowserTestCase):
         subobj_path = '/'.join(subobj.getPhysicalPath())
 
         self.assertEquals(TableRow,
-                          type(folder_contents.row_by_path(obj_path)))
+                          type(folder_contents.row_by_path(obj_path, browser=browser)))
 
         with self.assertRaises(ValueError) as cm:
-            folder_contents.row_by_path(subobj_path)
+            folder_contents.row_by_path(subobj_path, browser=browser)
         self.assertEquals(
             'The object with path "/plone/foo/bar" is not visible.'
             " Visible objects: ['/plone/foo']",

--- a/ftw/testbrowser/tests/test_pages_plone.py
+++ b/ftw/testbrowser/tests/test_pages_plone.py
@@ -1,8 +1,8 @@
-from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import nondefault_browsing
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 
@@ -10,56 +10,56 @@ from plone.app.testing import TEST_USER_ID
 @all_drivers
 class TestPlonePageObject(BrowserTestCase):
 
-    @browsing
+    @nondefault_browsing
     def test_not_logged_in(self, browser):
         browser.open(self.portal.portal_url())
-        self.assertFalse(plone.logged_in())
+        self.assertFalse(plone.logged_in(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_logged_in(self, browser):
         browser.login().open(self.portal.portal_url())
-        self.assertEquals(TEST_USER_ID, plone.logged_in())
+        self.assertEquals(TEST_USER_ID, plone.logged_in(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_view_on_root(self, browser):
         browser.open()
-        self.assertEquals('listing_view', plone.view())
+        self.assertEquals('listing_view', plone.view(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_view_on_login_form(self, browser):
         browser.open(view='login_form')
-        self.assertEquals('login_form', plone.view())
+        self.assertEquals('login_form', plone.view(browser=browser))
 
 
-    @browsing
+    @nondefault_browsing
     def test_portal_type(self, browser):
         browser.open()
-        self.assertEquals('plone-site', plone.portal_type())
+        self.assertEquals('plone-site', plone.portal_type(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_view_and_portal_type(self, browser):
         browser.open()
         self.assertEquals(('listing_view', 'plone-site'),
-                          plone.view_and_portal_type())
+                          plone.view_and_portal_type(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_first_heading(self, browser):
         browser.open()
-        self.assertEquals('Plone site', plone.first_heading())
+        self.assertEquals('Plone site', plone.first_heading(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_first_heading_on_at_addform(self, browser):
         browser.login(SITE_OWNER_NAME).open()
-        factoriesmenu.add('Folder')
-        self.assertEquals('Add Folder', plone.first_heading())
+        factoriesmenu.add('Folder', browser=browser)
+        self.assertEquals('Add Folder', plone.first_heading(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_document_description(self, browser):
         browser.login(SITE_OWNER_NAME).open(view='overview-controlpanel')
         self.assertEquals('Configuration area for Plone and add-on Products.',
-                          plone.document_description())
+                          plone.document_description(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_no_document_description(self, browser):
         browser.open()
-        self.assertEquals(None, plone.document_description())
+        self.assertEquals(None, plone.document_description(browser=browser))

--- a/ftw/testbrowser/tests/test_pages_statusmessages.py
+++ b/ftw/testbrowser/tests/test_pages_statusmessages.py
@@ -1,102 +1,103 @@
-from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import nondefault_browsing
 
 
 @all_drivers
 class TestStatusmessages(BrowserTestCase):
 
-    @browsing
+    @nondefault_browsing
     def test_messages(self, browser):
         browser.open(view='test-statusmessages')
         self.assertEquals(
             {'info': ['An info message.'],
              'warning': ['A warning message.'],
              'error': ['An error message.']},
-            statusmessages.messages())
+            statusmessages.messages(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_info_messages(self, browser):
         browser.open(view='test-statusmessages')
         self.assertEquals(['An info message.'],
-                          statusmessages.info_messages())
+                          statusmessages.info_messages(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_warning_messages(self, browser):
         browser.open(view='test-statusmessages')
         self.assertEquals(['A warning message.'],
-                          statusmessages.warning_messages())
+                          statusmessages.warning_messages(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_error_messages(self, browser):
         browser.open(view='test-statusmessages')
         self.assertEquals(['An error message.'],
-                          statusmessages.error_messages())
+                          statusmessages.error_messages(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_as_string(self, browser):
         browser.open(view='test-statusmessages')
         self.assertEquals(
             '"[ERROR] An error message.", '
             '"[INFO] An info message.", '
             '"[WARNING] A warning message."',
-            statusmessages.as_string())
+            statusmessages.as_string(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_as_string_with_filtering(self, browser):
         browser.open(view='test-statusmessages')
         self.assertEquals(
             '"[WARNING] A warning message."',
-            statusmessages.as_string('warning'))
+            statusmessages.as_string('warning', browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_assert_message(self, browser):
         browser.open(view='test-statusmessages')
-        self.assertTrue(statusmessages.assert_message('A warning message.'))
+        self.assertTrue(statusmessages.assert_message('A warning message.',
+                                                      browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_assert_message_failure(self, browser):
         browser.open(view='test-statusmessages?type=info')
         with self.assertRaises(AssertionError) as cm:
-            statusmessages.assert_message('a message')
+            statusmessages.assert_message('a message', browser=browser)
 
         self.assertEquals('No status message "a message". Current messages:'
                           ' "[INFO] An info message."',
                           str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_assert_no_messages(self, browser):
         browser.open()
-        self.assertTrue(statusmessages.assert_no_messages())
+        self.assertTrue(statusmessages.assert_no_messages(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_assert_no_messages_failure(self, browser):
         browser.open(view='test-statusmessages?type=warning')
         with self.assertRaises(AssertionError) as cm:
-            statusmessages.assert_no_messages()
+            statusmessages.assert_no_messages(browser=browser)
 
         self.assertEquals('Unexpected status messages:'
                           ' "[WARNING] A warning message."',
                           str(cm.exception))
 
-    @browsing
+    @nondefault_browsing
     def test_assert_no_error_messages(self, browser):
         browser.open(view='test-statusmessages?type=warning')
         self.assertEquals(
             {'info': [],
              'warning': ['A warning message.'],
              'error': []},
-            statusmessages.messages())
+            statusmessages.messages(browser=browser))
 
-        self.assertTrue(statusmessages.assert_no_error_messages())
+        self.assertTrue(statusmessages.assert_no_error_messages(browser=browser))
 
-    @browsing
+    @nondefault_browsing
     def test_assert_no_error_messages_failure(self, browser):
         browser.open(view='test-statusmessages')
 
         with self.assertRaises(AssertionError) as cm:
-            statusmessages.assert_no_error_messages()
+            statusmessages.assert_no_error_messages(browser=browser)
 
         self.assertEquals('Unexpected "error" status messages:'
                           ' "[ERROR] An error message."',

--- a/ftw/testbrowser/tests/test_pages_z3cform.py
+++ b/ftw/testbrowser/tests/test_pages_z3cform.py
@@ -1,23 +1,23 @@
-from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import z3cform
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testbrowser.tests.helpers import nondefault_browsing
 
 
 @all_drivers
 class TestZ3cformPageObject(BrowserTestCase):
 
-    @browsing
+    @nondefault_browsing
     def test_erroneous_fields(self, browser):
         self.grant('Manager')
 
         browser.login().open()
-        factoriesmenu.add('Folder')
+        factoriesmenu.add('Folder', browser=browser)
         browser.find('Save').click()
 
         self.assertEquals(browser.previous_url, browser.url)
 
         form = browser.css('form#form').first
         self.assertEquals({u'Title': ['Required input is missing.']},
-                          z3cform.erroneous_fields(form))
+                          z3cform.erroneous_fields(form, browser=browser))


### PR DESCRIPTION
**Background**
Page objects support passing in a browser instance so that they can be used in a multi browser setup (e.g. when testing two users concurrently).

**Problem**
I have realized that not all page objects used this pattern consistently. Some didn't accept the browser keyword argument, others didn't use the browser instance recursively by passing it to other page objects. Therefore this change.

**Solution**
This pull request includes these changes:
- A new `@nondefault_browsing` decorator allows to run the tests on a clone. This will lead to errors when page object access the default browser, since the default browser never opens a page.
- All standard page object tests now use the `@nondefault_browsing` decorator.
- Page objects which didn't accept the `browser` keyword were updated to do so.
- Page objects which didn't pass the custom browser instance to other page objects were updated to do so.
- Some docstrings were updated according to signature changes.
- The folder contents page object documentation is now published too.