### PR TITLE
Plone 5.1.x Support (NG)

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 parts +=

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.27.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add Plone 5.1 support. [jone, maethu]
 
 
 1.27.0 (2017-09-15)
@@ -118,7 +118,6 @@ Changelog
 1.21.0 (2017-04-19)
 -------------------
 
-- Add Plone 5.1 support. [jone]
 - Make ``zope.globalrequest`` support optional. [jone]
 - Add testing layers for setting the default driver. [jone]
 - Add ``default_driver`` option to the driver. [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -118,6 +118,7 @@ Changelog
 1.21.0 (2017-04-19)
 -------------------
 
+- Add Plone 5.1 support. [jone]
 - Make ``zope.globalrequest`` support optional. [jone]
 - Add testing layers for setting the default driver. [jone]
 - Add ``default_driver`` option to the driver. [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.27.1 (unreleased)
 -------------------
 
+- Let traversal driver support plone.protect>=3 auto CSRF protection. [jone]
 - Add Plone 5.1 support. [jone, maethu]
 
 

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -820,14 +820,23 @@ class Browser(object):
         if self.document is None:
             raise ContextNotFound('Not viewing any page.')
 
-        base_tags = self.css('base')
-        if len(base_tags) == 0:
-            raise ContextNotFound('No <base> tag found on current page.')
-        elif len(base_tags) > 1:
-            raise ContextNotFound('Unexpectedly found multiple <base> tags.')
-        base, = base_tags
+        url = None
 
-        url = base.attrib['href']
+        # Plone 4: <base url="..." />
+        base_tags = self.css('base')
+        if len(base_tags) == 1:
+            base, = base_tags
+            url = base.attrib['href']
+
+        # Plone 5: <body data-base-url="...">
+        body_tags = self.css('body')
+        if not url and len(body_tags) == 1:
+            url = body_tags.first.attrib.get('data-base-url', None)
+
+        if not url:
+            raise ContextNotFound(
+                'No <base> tag and no <body data-base-url> found.')
+
         path = urlparse.urlparse(url).path.rstrip('/')
         portal = getSite()
         portal_path = '/'.join(portal.getPhysicalPath())

--- a/ftw/testbrowser/drivers/traversaldriver.py
+++ b/ftw/testbrowser/drivers/traversaldriver.py
@@ -419,11 +419,25 @@ class TraversalDriver(object):
         from plone.protect.auto import safeWrite
         from plone.transformchain.interfaces import ITransform
 
+        self._ensure_plone_catalog_queue_processed()
+
         transform = getMultiAdapter((getSite(), event.request),
                                     ITransform,
                                     name='plone.protect.autocsrf')
         for obj in transform._registered_objects():
             safeWrite(obj, event.request)
+
+    def _ensure_plone_catalog_queue_processed(self):
+        """In order for marking added objects as safe in plone.protect,
+        we must ensure that the catalog is processed and those objects
+        actually are created at this point.
+        """
+        try:
+            from Products.CMFCore.indexing import processQueue
+        except ImportError:
+            pass
+        else:
+            processQueue()
 
     def reload(self):
         if self.previous_make_request is None:

--- a/ftw/testbrowser/drivers/traversaldriver.py
+++ b/ftw/testbrowser/drivers/traversaldriver.py
@@ -24,6 +24,7 @@ preparation we use the ``requests`` module.
 
 
 from Acquisition import aq_base
+from contextlib import contextmanager
 from ftw.testbrowser.drivers.utils import isolated
 from ftw.testbrowser.drivers.utils import remembering_for_reload
 from ftw.testbrowser.exceptions import BlankPage
@@ -34,6 +35,9 @@ from requests.structures import CaseInsensitiveDict
 from StringIO import StringIO
 from urllib import unquote
 from urlparse import urlparse
+from zope.component import getGlobalSiteManager
+from zope.component import getMultiAdapter
+from zope.component.hooks import getSite
 from zope.interface import implements
 from ZPublisher.BaseRequest import RequestContainer
 from ZPublisher.Iterators import IStreamIterator
@@ -41,6 +45,7 @@ from ZPublisher.Response import Response
 from ZPublisher.Test import publish_module
 import gzip
 import httplib
+import pkg_resources
 import requests
 import sys
 import Zope2
@@ -230,17 +235,18 @@ class TraversalDriver(object):
         app = aq_base(self.browser.app).__of__(requestcontainer)
 
         with self.transactions_manager(zope_request, app):
-            try:
-                publish_module(
-                    'Zope2',
-                    response=response,
-                    request=zope_request,
-                    debug=self.browser.exception_bubbling)
+            with self._plone_protect_autocsrf_handling():
+                try:
+                    publish_module(
+                        'Zope2',
+                        response=response,
+                        request=zope_request,
+                        debug=self.browser.exception_bubbling)
 
-            except:
-                self.response = None
-                self.current_url = None
-                raise
+                except:
+                    self.response = None
+                    self.current_url = None
+                    raise
 
         self._extract_cookies(prepared_request, response)
         self.response = response
@@ -357,6 +363,67 @@ class TraversalDriver(object):
         with gzip.GzipFile(fileobj=StringIO(self.response.body)) as zipfile:
             self.response.body = zipfile.read()
             self.response.headers.pop('content-encoding', None)
+
+    @contextmanager
+    def _plone_protect_autocsrf_handling(self):
+        """Support plone.protect's auto CSRF protection as good as possible.
+
+        The problem is that we use the same connection and transaction for
+        preparation as for performing a request with ftw.testbrowser.
+
+        This means that we may already have changed objects on the connection
+        but the change is not from within the request.
+
+        We fix that by marking all objects which are already marked as changed
+        on the current as safe for CSRF.
+        This also means that the auto protection does no longer trigger within
+        the test for the followed requests.
+        """
+
+        if not self._is_plone_protect_autocsrf_enabled():
+            # Abort but do not break context manager.
+            yield
+            return
+
+        from ZPublisher.interfaces import IPubAfterTraversal
+
+        site_manager = getGlobalSiteManager()
+        site_manager.registerHandler(
+            self._plone_protect_mark_all_as_save, [IPubAfterTraversal])
+        try:
+            yield
+        finally:
+            site_manager.unregisterHandler(
+                self._plone_protect_mark_all_as_save, [IPubAfterTraversal])
+
+
+    def _is_plone_protect_autocsrf_enabled(self):
+        """Returns whether we expect the plone.protect auto CSRF protection
+        to be enabled.
+        It is usually enabled in Plone 5.
+        """
+
+        try:
+            dist = pkg_resources.get_distribution('plone.protect')
+        except pkg_resources.DistributionNotFound:
+            # plone.protect is not installed
+            return False
+        else:
+            # auto CSRF is enabled in plone.protect>=3
+            return int(dist.version.split('.')[0]) >= 3
+
+    def _plone_protect_mark_all_as_save(self, event):
+        """Event handler for marking all objects touched on this connection
+        as save writes.
+        """
+        from plone.protect.auto import safeWrite
+        from plone.transformchain.interfaces import ITransform
+
+        transform = getMultiAdapter((getSite(), event.request),
+                                    ITransform,
+                                    name='plone.protect.autocsrf')
+        for obj in transform._registered_objects():
+            safeWrite(obj, event.request)
 
     def reload(self):
         if self.previous_make_request is None:

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -8,6 +8,7 @@ from mechanize._form import MimeWriter
 from StringIO import StringIO
 import lxml.html.formfill
 import mimetypes
+import pkg_resources
 import shutil
 import urllib
 import urlparse
@@ -353,6 +354,13 @@ class Form(NodeWrapper):
                               'form-data; name="%s"' % fieldname, 1)
                 f = mw2.startbody(prefix=0)
                 f.write(value)
+
+        if pkg_resources.get_distribution('lxml').version >= '3.6.1':
+            # Since lxml 3.6.1 the lxml.html.form_values no longer include
+            # "file"-inputs, therefore we need to treat them as extra values.
+            for field in self.inputs:
+                if getattr(field, 'type', None) == 'file':
+                    field.write_mime_data(mw)
 
         mw.lastpart()
         value = data.getvalue()

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -375,12 +375,20 @@ class TextAreaField(NodeWrapper):
         if self.node.label is not None:
             return
 
-        if not self.attrib.get('id', None):
+        if self.attrib.get('id', None):
+            # Tinymce with dexterity has not the same label "for" as ids
+            # on the textarea.
+            for_attribute = self.attrib['id'].replace('.', '-')
+
+        elif self.attrib.get('name', None):
+            # TinyCME in Plone 5 has a even wronger structure, the textarea has
+            # no id attr at all.
+            for_attribute = self.attrib['name'].replace('.', '-')
+            self.attrib['id'] = for_attribute
+
+        else:
             return
 
-        # Tinymce with dexterity has not the same label "for" as ids
-        # on the textarea.
-        for_attribute = self.attrib['id'].replace('.', '-')
         label = self.body.xpath('//label[@for="%s"]' % for_attribute)
         if len(label) > 0:
             self.node.label = label.first.node

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -61,6 +61,11 @@ class Form(NodeWrapper):
                          normalize_spaces(input.label.raw_text)):
                 return input
 
+            checkbox_labels = (input.label is not None and
+                               input.label.css('>span.label'))
+            if checkbox_labels and label == checkbox_labels.first.text:
+                return input
+
         return self.find_widget(label_or_name)
 
     @wrapped_nodes
@@ -266,6 +271,11 @@ class Form(NodeWrapper):
                 labels.append(label)
             elif input.name:
                 labels.append(input.name)
+
+            checkbox_labels = (input.label is not None and
+                               input.label.css('>span.label'))
+            if checkbox_labels:
+                labels.append(checkbox_labels.first.text)
 
         return labels
 

--- a/ftw/testbrowser/nodes.py
+++ b/ftw/testbrowser/nodes.py
@@ -74,7 +74,11 @@ def wrapped_nodes(func, browser=_marker):
 def wrap_nodes(nodes, browser, query_info):
     """Wrap one or many nodes.
     """
-    if not isinstance(nodes, RESULT_SET_TYPES):
+    # lxml's C-code generator type is not types.GeneratorType.
+    is_generator = isinstance(nodes, types.GeneratorType) \
+                   or type(nodes).__name__ == 'generator'
+
+    if not isinstance(nodes, RESULT_SET_TYPES) and not is_generator:
         return wrap_node(nodes, browser)
 
     result = Nodes(query_info=query_info)

--- a/ftw/testbrowser/pages/editbar.py
+++ b/ftw/testbrowser/pages/editbar.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.queryinfo import QueryInfo
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.utils import normalize_spaces
 
 
@@ -13,7 +14,7 @@ def visible(browser=default_browser):
     :returns: ``True`` when the editbar is visible, ``False`` when it is not.
     :rtype: boolean
     """
-    return len(browser.css('#edit-bar')) > 0
+    return len(browser.css('#edit-bar, #edit-zone')) > 0
 
 
 def contentviews(browser=default_browser):
@@ -25,7 +26,12 @@ def contentviews(browser=default_browser):
     :returns: A list of the labels of the visible content views.
     :rtype: list of str
     """
-    return container(browser=browser).css('.contentViews >li >a').text
+    return container(browser=browser).css(
+        # Plone 4
+        '.contentViews >li >a, '
+        # PLone 5
+        'nav li[id^="contentview-"] > a'
+    ).text
 
 
 @QueryInfo.build
@@ -41,8 +47,7 @@ def contentview(label, browser=default_browser, query_info=None):
     :rtype: :py:class:`ftw.testbrowser.nodes.NodeWrapper`
     :raises: :py:exc:`ftw.testbrowser.exceptions.NoElementFound`
     """
-    contentviews_node = container(browser=browser).css('.contentViews').first
-    link = contentviews_node.find(label)
+    link = container(browser=browser).find(label)
     if link is None:
         query_info.add_hint('Visible content views: {!r}.'.format(
             contentviews(browser=browser)))
@@ -63,7 +68,11 @@ def menus(browser=default_browser):
     return map(
         lambda text: text.rstrip(u'\u2026'),  # Add new...
         container(browser=browser).css(
-            '#contentActionMenus .actionMenuHeader > a > span:first-child').text)
+            # Plone 4
+            '#contentActionMenus .actionMenuHeader > a > span:first-child, '
+            # Plone 5
+            'nav li[id^="plone-contentmenu-"] > a > span.plone-toolbar-title'
+        ).text)
 
 
 @QueryInfo.build
@@ -79,11 +88,20 @@ def menu(label, browser=default_browser, query_info=None):
     :rtype: :py:class:`ftw.testbrowser.nodes.NodeWrapper`
     :raises: :py:exc:`ftw.testbrowser.exceptions.NoElementFound`
     """
-    menus_node = container(browser=browser).css('#contentActionMenus').first
+
     label = normalize_spaces(label).rstrip(u'\u2026')
-    for span in menus_node.css('.actionMenuHeader > a > span:first-child'):
-        if normalize_spaces(span.text_content()).rstrip(u'\u2026') == label:
-            return span.parent('.actionMenu')
+
+    if IS_PLONE_4:
+        menus_node = container(browser=browser).css('#contentActionMenus').first
+        for span in menus_node.css('.actionMenuHeader > a > span:first-child'):
+            if normalize_spaces(span.text_content()).rstrip(u'\u2026') == label:
+                return span.parent('.actionMenu')
+
+    else:
+        for menu in container(browser=browser).css('nav li[id^="plone-contentmenu-"]'):
+            for span in menu.css('a > span.plone-toolbar-title'):
+                if normalize_spaces(span.text_content()).rstrip(u'\u2026') == label:
+                    return menu
 
     query_info.add_hint('Visible menus: {!r}.'.format(menus(browser=browser)))
     raise NoElementFound(query_info)
@@ -101,7 +119,11 @@ def menu_options(menu_label, browser=default_browser):
     :rtype: list of str
     """
     menu_container = menu(menu_label, browser=browser)
-    return menu_container.css('.actionMenuContent a .subMenuTitle').text
+    return menu_container.css(
+        # Plone 4
+        '.actionMenuContent a .subMenuTitle, '
+        # Plone 5
+        '> ul > li > a').text
 
 
 @QueryInfo.build
@@ -123,7 +145,11 @@ def menu_option(menu_label, option_label, browser=default_browser,
 
     menu_container = menu(menu_label, browser=browser, query_info=query_info)
     option_label = normalize_spaces(option_label)
-    for link in menu_container.css('.actionMenuContent a'):
+    for link in menu_container.css(
+            # Plone 4
+            '.actionMenuContent a, '
+            # Plone 5
+            '> ul > li > a'):
         if normalize_spaces(link.text_content()) == option_label:
             return link
 
@@ -140,8 +166,8 @@ def container(browser=default_browser):
     :param browser: The browser instance to operate with. Uses the global singleton
       default browser by default.
     :type browser: :py:class:`ftw.testbrowser.core.Browser`
-    :returns: The ``#edit-bar`` container node.
+    :returns: The ``#edit-bar`` or ``#edit-zone`` container node.
     :rtype: :py:class:`ftw.testbrowser.nodes.NodeWrapper`
     :raises: :py:exc:`ftw.testbrowser.exceptions.NoElementFound`
     """
-    return browser.css('#edit-bar').first
+    return browser.css('#edit-bar, #edit-zone').first

--- a/ftw/testbrowser/pages/factoriesmenu.py
+++ b/ftw/testbrowser/pages/factoriesmenu.py
@@ -33,7 +33,9 @@ def add(type_name, browser=default_browser):
         raise ValueError('Cannot add "%s": no factories menu visible.' % (
                 type_name))
 
-    links = menu(browser=browser).css('.actionMenuContent').find(type_name)
+    # Plone 4: .actionMenuContent
+    # Plone 5: >ul
+    links = menu(browser=browser).css('.actionMenuContent, >ul').find(type_name)
     if len(links) == 0:
         raise ValueError('The type "%s" is not addable. Addable types: %s' % (
                 type_name,

--- a/ftw/testbrowser/pages/factoriesmenu.py
+++ b/ftw/testbrowser/pages/factoriesmenu.py
@@ -52,4 +52,6 @@ def addable_types(browser=default_browser):
     if not visible(browser=browser):
         raise ValueError('Factories menu is not visible.')
 
-    return menu(browser=browser).css('.actionMenuContent a').text
+    # Plone 4: .actionMenuContent
+    # Plone 5: >ul
+    return menu(browser=browser).css('.actionMenuContent, >ul').css('a').text

--- a/ftw/testbrowser/pages/folder_contents.py
+++ b/ftw/testbrowser/pages/folder_contents.py
@@ -1,8 +1,21 @@
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.nodes import wrap_nodes
+from ftw.testbrowser.tests import IS_PLONE_4
 from operator import itemgetter
 
 
+def only_plone_4(func):
+    def wrapper(*args, **kwargs):
+        if IS_PLONE_4:
+            return func(*args, **kwargs)
+        else:
+            raise NotImplementedError('The folder_contents page object '
+                                      'is not implemented for plone 5 so'
+                                      'far, since js is not yet supported.')
+    return wrapper
+
+
+@only_plone_4
 def titles(browser=default_browser):
     """Returns all titles of the objects listed on the folder contents view.
 
@@ -14,6 +27,7 @@ def titles(browser=default_browser):
     return title_cells(browser=browser).text
 
 
+@only_plone_4
 def title_cells(browser=default_browser):
     """Returns all the cell of the title column.
 
@@ -27,6 +41,7 @@ def title_cells(browser=default_browser):
     return wrap_nodes(cells, browser=browser)
 
 
+@only_plone_4
 def dicts(browser=default_browser, **kwargs):
     """Returns the folder contents table rows as dicts, as described
     in :py:func:`ftw.testbrowser.table.Table.dicts`.
@@ -40,6 +55,7 @@ def dicts(browser=default_browser, **kwargs):
     return table(browser=browser).dicts(head_offset=1, **kwargs)
 
 
+@only_plone_4
 def select(*objects, **kwargs):
     """Selects the checkboxes on one or more rows by objects.
 
@@ -53,6 +69,7 @@ def select(*objects, **kwargs):
     select_rows([row_by_object(obj, browser=browser) for obj in objects])
 
 
+@only_plone_4
 def select_by_title(*titles, **kwargs):
     """Selects the checkboxes on one or more rows by the title of
     the objects.
@@ -67,6 +84,7 @@ def select_by_title(*titles, **kwargs):
     select_rows([row_by_title(title, browser=browser) for title in titles])
 
 
+@only_plone_4
 def select_by_path(*paths, **kwargs):
     """Selects the checkboxes on one or more rows by the path of
     the objects.
@@ -81,6 +99,7 @@ def select_by_path(*paths, **kwargs):
     select_rows([row_by_path(path, browser=browser) for path in paths])
 
 
+@only_plone_4
 def select_rows(rows):
     """Select the checkboxes of set of rows.
 
@@ -92,6 +111,7 @@ def select_rows(rows):
         checkbox.set('checked', '')
 
 
+@only_plone_4
 def row_by_title(title, browser=default_browser):
     """Returns the row for an object by its title.
 
@@ -118,6 +138,7 @@ def row_by_title(title, browser=default_browser):
                 title, urls))
 
 
+@only_plone_4
 def row_by_object(obj, browser=default_browser):
     """Returns the row for an object.
 
@@ -132,6 +153,7 @@ def row_by_object(obj, browser=default_browser):
     return row_by_path(path, browser=browser)
 
 
+@only_plone_4
 def row_by_path(path, browser=default_browser):
     """Returns the row for an object by its path.
 
@@ -152,6 +174,7 @@ def row_by_path(path, browser=default_browser):
                 path, rows.keys()))
 
 
+@only_plone_4
 def table(browser=default_browser):
     """The folder contents table node.
 
@@ -164,6 +187,7 @@ def table(browser=default_browser):
     return browser.css(selector).first
 
 
+@only_plone_4
 def form(browser=default_browser):
     """The folder contents form node.
 
@@ -175,6 +199,7 @@ def form(browser=default_browser):
     return browser.css('form[name=folderContentsForm]').first
 
 
+@only_plone_4
 def selected_paths(browser=default_browser):
     """Returns the paths of checkboxes currently selected.
 
@@ -186,6 +211,7 @@ def selected_paths(browser=default_browser):
     return tuple(form(browser=browser).values['paths:list'])
 
 
+@only_plone_4
 def rows_by_path(browser=default_browser):
     """Return a mapping of paths to row objects.
 
@@ -201,6 +227,7 @@ def rows_by_path(browser=default_browser):
     return result
 
 
+@only_plone_4
 def column_title_by_name(name, browser=default_browser):
     """Find a column title by the name of the column.
 

--- a/ftw/testbrowser/pages/plone.py
+++ b/ftw/testbrowser/pages/plone.py
@@ -7,7 +7,9 @@ def logged_in(browser=default_browser):
     resturns the user-ID, otherwise ``False``.
     """
 
-    match = browser.css('#user-name')
+    # Plone 4: #user-name
+    # Plone 5: .plone-toolbar-submenu-header
+    match = browser.css('.plone-toolbar-submenu-header, #user-name')
     if match:
         return match[0].text.strip()
     else:

--- a/ftw/testbrowser/pages/plone.py
+++ b/ftw/testbrowser/pages/plone.py
@@ -8,8 +8,10 @@ def logged_in(browser=default_browser):
     """
 
     # Plone 4: #user-name
-    # Plone 5: .plone-toolbar-submenu-header
-    match = browser.css('.plone-toolbar-submenu-header, #user-name')
+    # Plone 5: #portal-personaltools .plone-toolbar-submenu-header
+    match = browser.css(
+        '#portal-personaltools .plone-toolbar-submenu-header,'
+        ' #user-name')
     if match:
         return match[0].text.strip()
     else:

--- a/ftw/testbrowser/pages/statusmessages.py
+++ b/ftw/testbrowser/pages/statusmessages.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser.utils import normalize_spaces
+import re
 
 
 def messages(browser=default_browser):
@@ -18,7 +19,22 @@ def messages(browser=default_browser):
             continue
 
         key = tuple(type_classes)[0]
-        text = normalize_spaces(' '.join(message.css('dd').text_content()))
+
+        if message.css('dd'):
+            # Plone 4: <dl class="portalMessage info">
+            #              <dt>Info</dt>
+            #              <dd>Message</dd>
+            #          </dl>
+            text = normalize_spaces(' '.join(message.css('dd').text_content()))
+
+        elif message.css('strong'):
+            # Plone 5: <div class="portalMessage info">
+            #              <strong>Info</strong>
+            #              Message
+            #          </div>
+            type_text = message.css('strong').first.text
+            text = re.sub(r'^{} *'.format(re.escape(type_text)), '', message.text)
+
         if not text:
             # message is empty - skip it
             continue

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -5,9 +5,9 @@ from ftw.builder.testing import set_builder_session_factory
 from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
 from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
+from ftw.testing import FTWIntegrationTesting
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
-from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PLONE_ZSERVER
 from plone.app.testing import PloneSandboxLayer
@@ -55,7 +55,7 @@ TRAVERSAL_TESTING = FunctionalTesting(
            TRAVERSAL_BROWSER_FIXTURE),
     name='ftw.testbrowser:functional:traversal')
 
-TRAVERSAL_INTEGRATION_TESTING = IntegrationTesting(
+TRAVERSAL_INTEGRATION_TESTING = FTWIntegrationTesting(
     bases=(BROWSER_FIXTURE,
            TRAVERSAL_BROWSER_FIXTURE),
     name='ftw.testbrowser:integration:traversal')

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -4,7 +4,11 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
+import pkg_resources
 import transaction
+
+
+IS_PLONE_4 = pkg_resources.get_distribution('Plone').version[:2] == '4.'
 
 
 class BrowserTestCase(TestCase):

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -296,16 +296,16 @@ class TestBrowserCore(BrowserTestCase):
         browser.open(view='login_form').fill(
             {'Login Name': TEST_USER_NAME,
              'Password': TEST_USER_PASSWORD}).submit()
-        self.assertTrue(browser.css('#user-name'))
+        self.assertTrue(plone.logged_in())
 
         with browser.clone() as subbrowser:
             subbrowser.open()
-            self.assertTrue(subbrowser.css('#user-name'))
+            self.assertTrue(plone.logged_in(subbrowser))
             subbrowser.find('Log out').click()
-            self.assertFalse(subbrowser.css('#user-name'))
+            self.assertFalse(plone.logged_in(subbrowser))
 
         browser.reload()
-        self.assertTrue(browser.css('#user-name'))
+        self.assertTrue(plone.logged_in())
 
     @browsing
     def test_cloning_a_browser_copies_headers(self, browser):

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -8,6 +8,7 @@ from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import capture_streams
 from ftw.testbrowser.tests.helpers import register_view
@@ -264,7 +265,11 @@ class TestBrowserCore(BrowserTestCase):
         folder_contents_url = portal_url + 'folder_contents'
 
         browser.login(SITE_OWNER_NAME).open(folder_contents_url)
-        self.assertEquals(portal_url, browser.base_url)
+        if IS_PLONE_4:
+            self.assertEquals(portal_url, browser.base_url)
+        else:
+            self.assertEquals(folder_contents_url, browser.base_url)
+
         self.assertEquals(folder_contents_url, browser.url)
 
     @browsing

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -5,8 +5,10 @@ from ftw.testbrowser.exceptions import ContextNotFound
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
+from unittest import skipUnless
 
 
 @all_drivers
@@ -28,6 +30,7 @@ class TestBrowserContext(BrowserTestCase):
         browser.login().visit(folder, view='folder_contents')
         self.assertEquals(folder, browser.context)
 
+    @skipUnless(IS_PLONE_4, 'Plone 5 has an unaffected implementation.')
     @browsing
     def test_context_when_url_contains_view(self, browser):
         browser.login(SITE_OWNER_NAME).open()

--- a/ftw/testbrowser/tests/test_context.py
+++ b/ftw/testbrowser/tests/test_context.py
@@ -58,7 +58,7 @@ class TestBrowserContext(BrowserTestCase):
         with self.assertRaises(ContextNotFound) as cm:
             browser.context
 
-        self.assertEquals('No <base> tag found on current page.',
+        self.assertEquals('No <base> tag and no <body data-base-url> found.',
                           str(cm.exception))
 
     @browsing

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -3,9 +3,10 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
-from plone.app.testing import SITE_OWNER_NAME
+from unittest import skipUnless
 
 
 @all_drivers
@@ -77,6 +78,7 @@ class TestDexterityForms(BrowserTestCase):
         self.sync_transaction()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
+    @skipUnless(IS_PLONE_4, 'Relation fields in Plone5 does not have radio buttons')
     @browsing
     def test_radio_button_values_are_preserved(self, browser):
         self.grant('Manager')

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -14,7 +14,7 @@ class TestDexterityForms(BrowserTestCase):
     @browsing
     def test_tinymce_formfill(self, browser):
         self.grant('Manager')
-        browser.login(SITE_OWNER_NAME).open()
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page',
                       'Text': '<p>The body text.</p>'}).find('Save').click()
@@ -23,7 +23,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_save_add_form(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': 'The page'}).save()
         statusmessages.assert_no_error_messages()
@@ -33,7 +34,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_fill_umlauts(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': u'F\xf6lder'}).save()
         statusmessages.assert_no_error_messages()
@@ -41,7 +43,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_changing_checkbox_values(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': u'Page',
                       'Exclude from navigation': True}).save()
@@ -58,7 +61,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_checkbox_values_are_preserved(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
 
         browser.fill({'Title': u'Page',
@@ -75,7 +79,8 @@ class TestDexterityForms(BrowserTestCase):
 
     @browsing
     def test_radio_button_values_are_preserved(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
+        self.grant('Manager')
+        browser.login().open()
         factoriesmenu.add('Page')
         browser.fill({'Title': u'Page used as relation'}).save()
         statusmessages.assert_no_error_messages()

--- a/ftw/testbrowser/tests/test_dexterity_forms.py
+++ b/ftw/testbrowser/tests/test_dexterity_forms.py
@@ -3,10 +3,8 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests import BrowserTestCase
-from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
-from unittest import skipUnless
 
 
 @all_drivers
@@ -78,9 +76,10 @@ class TestDexterityForms(BrowserTestCase):
         self.sync_transaction()
         self.assertTrue(IExcludeFromNavigation(browser.context).exclude_from_nav)
 
-    @skipUnless(IS_PLONE_4, 'Relation fields in Plone5 does not have radio buttons')
     @browsing
-    def test_radio_button_values_are_preserved(self, browser):
+    def test_relation_list_and_relation_choice_autocomplete_widgets(self, browser):
+        # Plone 4: AutocompleteWidget from plone.formwidget.contenttree
+        # Plone 5: Patternslib based Autocompletewidget
         self.grant('Manager')
         browser.login().open()
         factoriesmenu.add('Page')

--- a/ftw/testbrowser/tests/test_drivers_traversaldriver.py
+++ b/ftw/testbrowser/tests/test_drivers_traversaldriver.py
@@ -3,7 +3,10 @@ from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
 from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.testing import TRAVERSAL_TESTING
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from plone.app.testing import SITE_OWNER_NAME
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 from zope.interface.verify import verifyClass
 import transaction
 
@@ -16,18 +19,28 @@ class TestTraversalDriverImplementation(BrowserTestCase):
 
     @browsing
     def test_does_not_require_transaction_commit(self, browser):
-        self.portal.setTitle('New Plone Site')
+        if IS_PLONE_4:
+            self.portal.setTitle('New Plone Site')
+        else:
+            registry = getUtility(IRegistry)
+            registry['plone.site_title'] = u'New Plone Site'
+
         browser.open()
         self.assertEquals('New Plone Site', browser.css('title').first.text)
 
     @browsing
     def test_does_not_commit_transactions(self, browser):
-        self.assertEquals('Plone site', self.portal.Title())
-        browser.login(SITE_OWNER_NAME).open(view='edit')
+        browser.login(SITE_OWNER_NAME).open()
+        self.assertEquals(['Plone site'], browser.css('title').text)
+
+        browser.open(view='edit')
         browser.fill({'Site title': 'New site title'}).save()
 
-        self.assertEquals('New site title', self.portal.Title())
+        browser.open()
+        self.assertEquals(['New site title'], browser.css('title').text)
+
         transaction.begin()  # reset to last commited state
+        browser.open()
         self.assertEquals(
-            'Plone site', self.portal.Title(),
+            ['Plone site'], browser.css('title').text,
             'The traversal driver should not commit the transaction.')

--- a/ftw/testbrowser/tests/test_headers.py
+++ b/ftw/testbrowser/tests/test_headers.py
@@ -11,7 +11,9 @@ class TestMechanizeHeaders(BrowserTestCase):
     @browsing
     def test_headers(self, browser):
         browser.open()
-        self.assertIn(browser.headers.get('content-type'),
+        # Plone 4: utf-8
+        # Plone 5: UTF-8
+        self.assertIn(browser.headers.get('content-type').lower(),
                       ('text/html; charset=utf-8',
                        'text/html;charset=utf-8'))
 
@@ -21,5 +23,8 @@ class TestMechanizeHeaders(BrowserTestCase):
     @browsing
     def test_webdav_headers(self, browser):
         browser.webdav('get')
-        self.assertEquals('text/html;charset=utf-8',
-                          browser.headers.get('content-type'))
+        # Plone 4: text/html; charset=utf-8
+        # Plone 5: text/html;charset=UTF-8
+        self.assertEquals(
+            'text/html;charset=utf-8',
+            browser.headers.get('content-type').lower().replace(' ', ''))

--- a/ftw/testbrowser/tests/test_nodes.py
+++ b/ftw/testbrowser/tests/test_nodes.py
@@ -131,10 +131,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.css('div.missing').first
 
-        self.assertEquals(
-            'Empty result set: <NodeWrapper:div, id="content">.css(\'div.missing\')'
-            ' did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <NodeWrapper:div, id="content">'
+                '.css(\'div.missing\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <NodeWrapper:article, id="content">'
+                '.css(\'div.missing\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_NoElementFound__with_xpath_on_node(self, browser):
@@ -143,10 +149,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.xpath('//table').first
 
-        self.assertEquals(
-            'Empty result set: <NodeWrapper:div, id="content">.xpath(\'//table\')'
-            ' did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <NodeWrapper:div, id="content">'
+                '.xpath(\'//table\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <NodeWrapper:article, id="content">'
+                '.xpath(\'//table\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_NoElementFound__with_css_on_result_set(self, browser):
@@ -155,10 +167,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.css('div.missing').first
 
-        self.assertEquals(
-            'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
-            '.css(\'div.missing\') did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
+                '.css(\'div.missing\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <Nodes: [<NodeWrapper:article, id="content">]>'
+                '.css(\'div.missing\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_NoElementFound__with_xpath_on_result_set(self, browser):
@@ -167,10 +185,16 @@ class TestNodesResultSet(BrowserTestCase):
         with self.assertRaises(NoElementFound) as cm:
             content.xpath('//table').first
 
-        self.assertEquals(
-            'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
-            '.xpath(\'//table\') did not match any nodes.',
-            str(cm.exception))
+        self.assertIn(
+            str(cm.exception),
+            (
+                # Plone 4:
+                'Empty result set: <Nodes: [<NodeWrapper:div, id="content">]>'
+                '.xpath(\'//table\') did not match any nodes.',
+                # Plone 5:
+                'Empty result set: <Nodes: [<NodeWrapper:article, id="content">]>'
+                '.xpath(\'//table\') did not match any nodes.',
+            ))
 
     @browsing
     def test_first_or_none_is_first_node(self, browser):

--- a/ftw/testbrowser/tests/test_pages_folder_contents.py
+++ b/ftw/testbrowser/tests/test_pages_folder_contents.py
@@ -3,10 +3,24 @@ from ftw.builder import create
 from ftw.testbrowser.pages import folder_contents
 from ftw.testbrowser.table import TableRow
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import nondefault_browsing
+from unittest import skipIf
+from unittest import skipUnless
 
 
+@skipIf(IS_PLONE_4, 'folder_contents in plone 5 is js only.')
+@all_drivers
+class TestFolderContentsIsNotImplemented(BrowserTestCase):
+
+    def test_import_raises_notimplementederror(self):
+        with self.assertRaises(NotImplementedError):
+            from ftw.testbrowser.pages.folder_contents import titles
+            titles()
+
+
+@skipUnless(IS_PLONE_4, 'folder_contents in plone 5 is js only.')
 @all_drivers
 class TestFolderContents(BrowserTestCase):
 

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -326,7 +326,9 @@ class TestBrowserRequests(BrowserTestCase):
     @browsing
     def test_response_contenttype(self, browser):
         browser.open()
-        self.assertIn(browser.contenttype,
+        # Plone 4: utf-8
+        # Plone 5 UTF-8
+        self.assertIn(browser.contenttype.lower(),
                       ('text/html;charset=utf-8',
                        'text/html; charset=utf-8'))
 
@@ -344,7 +346,9 @@ class TestBrowserRequests(BrowserTestCase):
     @browsing
     def test_response_encoding(self, browser):
         browser.open()
-        self.assertEquals('utf-8', browser.encoding)
+        # Plone 4: utf-8
+        # Plone 5 UTF-8
+        self.assertEquals('utf-8', browser.encoding.lower())
 
         browser.open(self.json_view_url, data={'foo': 'bar'})
         self.assertEquals(None, browser.encoding)

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -8,6 +8,7 @@ from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import RedirectLoopException
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_4
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.alldrivers import skip_driver
 from ftw.testbrowser.tests.helpers import register_view
@@ -18,6 +19,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from StringIO import StringIO
+from unittest import skipUnless
 from zExceptions import BadRequest
 from zope.component import getUtility
 from zope.publisher.browser import BrowserView
@@ -400,6 +402,7 @@ class TestBrowserRequests(BrowserTestCase):
             'URL: {}/test-redirect-loop'.format(self.portal.absolute_url()),
             str(cm.exception))
 
+    @skipUnless(IS_PLONE_4, 'gzip compression was removed in Plone 5.')
     @browsing
     def test_decompresses_gzip_responses(self, browser):
         browser.login().open()

--- a/ftw/testbrowser/tests/test_widgets_datetime.py
+++ b/ftw/testbrowser/tests/test_widgets_datetime.py
@@ -4,10 +4,20 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+import transaction
 
 
 @all_drivers
 class TestDatetimeWidget(BrowserTestCase):
+
+    def setUp(self):
+        super(TestDatetimeWidget, self).setUp()
+        registry = getUtility(IRegistry)
+        if 'plone.portal_timezone' in registry:
+            registry['plone.portal_timezone'] = 'Europe/Berlin'
+            transaction.commit()
 
     @browsing
     def test_z3cform_formfill(self, browser):

--- a/ftw/testbrowser/tests/views/z3cform.py
+++ b/ftw/testbrowser/tests/views/z3cform.py
@@ -1,4 +1,5 @@
-from collective.z3cform.datagridfield import DictRow, DataGridFieldFactory
+from collective.z3cform.datagridfield import DataGridFieldFactory
+from collective.z3cform.datagridfield import DictRow
 from datetime import date
 from datetime import datetime
 from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
@@ -6,6 +7,7 @@ from plone.formwidget.contenttree import MultiContentTreeFieldWidget
 from plone.formwidget.contenttree import PathSourceBinder
 from plone.formwidget.contenttree import UUIDSourceBinder
 from plone.i18n.normalizer import idnormalizer
+from plone.uuid.interfaces import IUUID
 from plone.z3cform.layout import FormWrapper
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.browser.radio import RadioFieldWidget
@@ -156,6 +158,7 @@ class ShoppingForm(Form):
             if isinstance(value, (datetime, date)):
                 value = value.isoformat()
 
+            value = IUUID(value, value)
             self.result_data[key] = value
 
 

--- a/ftw/testbrowser/tests/views/z3cform.py
+++ b/ftw/testbrowser/tests/views/z3cform.py
@@ -2,6 +2,7 @@ from collective.z3cform.datagridfield import DataGridFieldFactory
 from collective.z3cform.datagridfield import DictRow
 from datetime import date
 from datetime import datetime
+from OFS.interfaces import IItem
 from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
 from plone.formwidget.contenttree import MultiContentTreeFieldWidget
 from plone.formwidget.contenttree import PathSourceBinder
@@ -154,11 +155,6 @@ class ShoppingForm(Form):
         for key, value in data.items():
             if not value:
                 continue
-
-            if isinstance(value, (datetime, date)):
-                value = value.isoformat()
-
-            value = IUUID(value, value)
             self.result_data[key] = value
 
 
@@ -169,6 +165,23 @@ class ShoppingView(FormWrapper):
     def render(self):
         if self.form_instance.result_data:
             self.request.RESPONSE.setHeader('Content-Type', 'application/json')
-            return json.dumps(self.form_instance.result_data)
+            return json.dumps(self.make_json_serializable(
+                self.form_instance.result_data))
         else:
             return super(ShoppingView, self).render()
+
+    def make_json_serializable(self, value):
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+
+        if IItem.providedBy(value):
+            return IUUID(value)
+
+        if isinstance(value, (list, tuple)):
+            return map(self.make_json_serializable, value)
+
+        if isinstance(value, dict):
+            return dict(zip(*map(self.make_json_serializable,
+                                 zip(*value.items()))))
+
+        return value

--- a/ftw/testbrowser/widgets/autocomplete.py
+++ b/ftw/testbrowser/widgets/autocomplete.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 from lxml import etree
+from plone.uuid.interfaces import IUUID
 import re
 
 
@@ -88,6 +89,38 @@ class AutocompleteWidget(PloneWidget):
         for value in values:
             if hasattr(value, 'getPhysicalPath'):
                 new_values.append('/'.join(value.getPhysicalPath()))
+            else:
+                new_values.append(value)
+        return new_values
+
+
+@widget
+class PatternsLibAutocompleteWidget(PloneWidget):
+    """Represents the Autocomplete widget implemented with patternslib"""
+
+    @staticmethod
+    def match(node):
+        if not PloneWidget.match(node):
+            return False
+
+        return len(node.css('[data-pat-relateditems]')) > 0
+
+    def fill(self, values):
+        """With patternslib the Relation fields are represented as
+        input text field containing one uid, or multiple uids seperated
+        by a colon.
+        """
+        if not isinstance(values, (list, set, tuple)):
+            values = [values]
+
+        values = self._resolve_objects_to_uid(values)
+        self.css('input').first.value = ':'.join(values)
+
+    def _resolve_objects_to_uid(self, values):
+        new_values = []
+        for value in values:
+            if hasattr(value, 'getPhysicalPath'):
+                new_values.append(IUUID(value))
             else:
                 new_values.append(value)
         return new_values

--- a/ftw/testbrowser/widgets/datagridwidget.py
+++ b/ftw/testbrowser/widgets/datagridwidget.py
@@ -4,6 +4,7 @@ from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 from ftw.testbrowser.widgets.base import WIDGETS
 from lxml.html import formfill
+from plone.uuid.interfaces import IUUID
 
 
 @widget
@@ -73,6 +74,7 @@ class DataGridWidget(PloneWidget):
                 return
 
         handlers = (
+            ('input[data-pat-relateditems]', self._fill_patternslib_relatedItems),
             ('input[type=text]', self._fill_text),
             ('select', self._fill_select),
             ('input[type=checkbox]', self._fill_checkbox),
@@ -98,3 +100,9 @@ class DataGridWidget(PloneWidget):
         else:
             value = ''
         return formfill._fill_multiple(node, value)
+
+    def _fill_patternslib_relatedItems(self, node, values):
+        if not isinstance(values, (list, set, tuple)):
+            values = [values]
+        values = map(IUUID, values)
+        node.value = ':'.join(values)

--- a/ftw/testbrowser/widgets/datetime.py
+++ b/ftw/testbrowser/widgets/datetime.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
+import json
 
 
 @widget
@@ -50,3 +51,27 @@ class DateTimeWidget(PloneWidget):
             return None
         else:
             return self.css(xpr).first
+
+
+@widget
+class PaternslibDateTimeWidget(PloneWidget):
+    """Represents the z3cform paternslib datetime widget.
+    """
+
+    field_selector = '>input[data-pat-pickadate]'
+
+    @staticmethod
+    def match(node):
+        if not PloneWidget.match(node):
+            return False
+
+        return len(node.css(PaternslibDateTimeWidget.field_selector)) == 1
+
+    def fill(self, value):
+        field = self.css(PaternslibDateTimeWidget.field_selector).first
+        config = json.loads(field.attrib['data-pat-pickadate'])
+
+        if config.get('time'):
+            field.set('value', value.strftime('%Y-%m-%d %H:%M'))
+        else:
+            field.set('value', value.strftime('%Y-%m-%d'))

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,11 @@ version = '1.27.1.dev0'
 
 
 tests_require = [
+    'Plone',
+    'Products.CMFCore',
+    'Products.CMFPlone',
+    'Products.GenericSetup',
+    'Products.statusmessages',
     'collective.z3cform.datagridfield',
     'ftw.builder',
     'ftw.testing',
@@ -18,10 +23,6 @@ tests_require = [
     'plone.formwidget.contenttree',
     'plone.i18n',
     'plone.z3cform',
-    'Products.CMFCore',
-    'Products.CMFPlone',
-    'Products.GenericSetup',
-    'Products.statusmessages',
     'transaction',
     'unittest2',
     'z3c.form',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(name='ftw.testbrowser',
       classifiers=[
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
+        'Framework :: Plone :: 5.1',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tests_require = [
     'Products.statusmessages',
     'collective.z3cform.datagridfield',
     'ftw.builder',
-    'ftw.testing',
+    'ftw.testing >= 1.17.0',
     'plone.app.content',
     'plone.app.contenttypes',
     'plone.app.dexterity',

--- a/sources.cfg
+++ b/sources.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    http://kgs.4teamwork.ch/sources.cfg
+
+extensions +=
+    mr.developer
+
+auto-checkout =

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,5 +1,6 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    sources.cfg
 
 package-name = ftw.testbrowser

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+
+package-name = ftw.testbrowser
+

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+    sources.cfg
 
 package-name = ftw.testbrowser
-


### PR DESCRIPTION
Replaces / closes https://github.com/4teamwork/ftw.testbrowser/pull/47

Introduce support for Plone 5.1.
- requires https://github.com/4teamwork/ftw.testing/pull/32 for integration testing with the traversal driver
- extends the traversal driver to support plone.protect's auto CSRF protection
- various fixes for page objects because of changes in Plone
- see separate commits for details