### PR TITLE
Factories menu: fix regression when menu visible but empty.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.28.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Factories menu: fix regression when menu visible but empty. [jone]
 
 1.28.0 (2017-10-03)
 -------------------

--- a/ftw/testbrowser/pages/factoriesmenu.py
+++ b/ftw/testbrowser/pages/factoriesmenu.py
@@ -54,4 +54,4 @@ def addable_types(browser=default_browser):
 
     # Plone 4: .actionMenuContent
     # Plone 5: >ul
-    return menu(browser=browser).css('.actionMenuContent, >ul').css('a').text
+    return menu(browser=browser).css('.actionMenuContent a, >ul a').text


### PR DESCRIPTION
When the factories menu is patched, it may be empty but still visible. In the Plone 5 update we've refactored the factories menu page object so that it does no longer support that.

Traceback:
```python
Error in test test_businesscase_dossier_is_not_addable_when_disallowed (opengever.repository.tests.test_menu.TestRepositoryFolderFactoryMenu)
Traceback (most recent call last):
  File "/Users/jone/projects/python/buildout.python/parts/opt/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/Users/jone/projects/2packages/opengever.core/src/ftw.testbrowser/ftw/testbrowser/__init__.py", line 42, in test_function
    return func(self, *args, **kwargs)
  File "/Users/jone/projects/2packages/opengever.core/opengever/repository/tests/test_menu.py", line 19, in test_businesscase_dossier_is_not_addable_when_disallowed
    self.assertNotIn('Business Case Dossier', factoriesmenu.addable_types())
  File "/Users/jone/projects/2packages/opengever.core/src/ftw.testbrowser/ftw/testbrowser/pages/factoriesmenu.py", line 57, in addable_types
    return menu(browser=browser).css('.actionMenuContent, >ul').css('a').text
  File "/Users/jone/projects/2packages/opengever.core/src/ftw.testbrowser/ftw/testbrowser/queryinfo.py", line 38, in wrapper
    return function(*args, **kwargs)
  File "/Users/jone/projects/2packages/opengever.core/src/ftw.testbrowser/ftw/testbrowser/nodes.py", line 251, in css
    map(methodcaller('css', css_selector, query_info), self)),
TypeError: reduce() of empty sequence with no initial value
```

I didn't write a test because it is not easily possible to reproduce this problem with a vanilla plone. But it's still a problem in some project for us.