### PR TITLE
Refactor plone.protect auto CSRF support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.28.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Refactor plone.protect auto CSRF support for compatibility
+  with ftw.testing's COMPONENT_REGISTRY_ISOLATION isolation layer. [jone]
 
 1.28.1 (2017-10-03)
 -------------------


### PR DESCRIPTION
Refactor `plone.protect`'s auto CSRF support to no longer rely on a temporarily registered event subscriber. By doing that we now support `ftw.testing`'s `COMPONENT_REGISTRY_ISOLATION` testing layer.