### PR TITLE
Fix browser.debug to finish writing file before opening.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.29.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix browser.debug to finish writing file before opening. [jone]
 
 1.29.1 (2017-11-08)
 -------------------

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -989,9 +989,10 @@ class Browser(object):
                 source = source.encode('utf-8')
 
             file_.write(source)
-            cmd = 'open {0}'.format(path)
-            print '> {0}'.format(cmd)
-            os.system(cmd)
+
+        cmd = 'open {0}'.format(path)
+        print '> {0}'.format(cmd)
+        os.system(cmd)
 
     def _verify_setup(self):
         if self.request_library is None:


### PR DESCRIPTION
Fixes a bug in browser.debug, causing that the file is opened (e.g. in nthe browser) before the data is flushed to the disk.

The reason for the bug is that the open subprocess is executed while the filehandle is still open and therefore the written data may or may not be written to the disk.