### PR TITLE
Fix unbound local error.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.29.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix unbound local error. [deiferni]
 
 
 1.29.3 (2017-11-23)

--- a/ftw/testbrowser/pages/z3cform.py
+++ b/ftw/testbrowser/pages/z3cform.py
@@ -20,6 +20,7 @@ def erroneous_fields(form, browser=default_browser):
         if not input.parent('.field.error'):
             continue
 
+        label = None
         if input.label is not None:
             label = input.label.text_content()
         if not label:


### PR DESCRIPTION
Have not managed to reproduce this in a simple test yet, unfortunately. I've run into this in `opengever.core` in combination with custom validators/error messages.

But looking at the code the change should be pretty obvious and also "correct" 😉 .