### PR TITLE
Improve extraction of erroneous fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.29.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Improve extraction of erroneous fields. [jone, mbaechtold]
 
 1.29.4 (2017-11-30)
 -------------------

--- a/ftw/testbrowser/pages/z3cform.py
+++ b/ftw/testbrowser/pages/z3cform.py
@@ -16,16 +16,8 @@ def erroneous_fields(form, browser=default_browser):
     """
 
     result = {}
-    for input in form.inputs:
-        if not input.parent('.field.error'):
-            continue
+    for field in form.css('.field.error'):
+        errors = field.css('.fieldErrorBox').text
+        result[field.css('label, div.label').first.text] = errors
 
-        label = None
-        if input.label is not None:
-            label = input.label.text_content()
-        if not label:
-            label = input.name
-
-        errors = input.parent('.field').css('.fieldErrorBox').normalized_text()
-        result[normalize_spaces(label)] = errors
     return result


### PR DESCRIPTION
This fixes a side-effect introduced in https://github.com/4teamwork/ftw.testbrowser/pull/80 where empty marker fields would also be added to the list of erroneous form fields.