### PR TITLE
Fix MIME encoding error when uploading files.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.29.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix MIME encoding error when uploading files and using unicode form values. [jone]
 
 1.29.5 (2017-12-04)
 -------------------

--- a/ftw/testbrowser/form.py
+++ b/ftw/testbrowser/form.py
@@ -355,6 +355,9 @@ class Form(NodeWrapper):
         mw.startmultipartbody("form-data", add_to_http_hdrs=True, prefix=0)
 
         for fieldname, value in values:
+            if isinstance(value, unicode):
+                value = value.encode('utf-8')
+
             field = self.find_field(fieldname)
             if isinstance(field, FileField):
                 field.write_mime_data(mw)

--- a/ftw/testbrowser/tests/test_file_uploads.py
+++ b/ftw/testbrowser/tests/test_file_uploads.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import asset
 from plone.app.testing import SITE_OWNER_NAME
@@ -76,6 +77,17 @@ class TestFileUploadsArchetypes(TestCase):
         with asset('file.pdf') as pdf:
             self.assertTrue(pdf.read().strip() == browser.contents.strip(),
                             'The PDF was changed when uploaded!')
+
+    @browsing
+    def test_upload_unicode(self, browser):
+        browser.login(SITE_OWNER_NAME).open()
+        factoriesmenu.add('File')
+
+        with asset('cities-utf8.xml') as pdf:
+            browser.fill({'Title': u'Hall\xf6chen',
+                          'File': pdf}).save()
+
+        statusmessages.assert_no_error_messages()
 
     def assert_file_download(self, data, browser, filename='foo.txt',
                              content_type='text/plain'):


### PR DESCRIPTION
When uploading files and also filling other form fields with unicode values, there was an error on the MIME preparation when reading the StringIO value.

The problem is fixed by ensuring that we always use UTF-8 when inserting MIME part values.