### PR TITLE
Respect HTTP response encoding

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.29.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix encoding problems for HTML documents without encoding declaration by respecting
+  the encoding in the content-type response header. [jone]
 
 1.29.7 (2018-04-30)
 -------------------

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -20,9 +20,9 @@ from ftw.testbrowser.interfaces import IBrowser
 from ftw.testbrowser.log import ExceptionLogger
 from ftw.testbrowser.nodes import wrap_nodes
 from ftw.testbrowser.nodes import wrapped_nodes
+from ftw.testbrowser.parser import TestbrowserHTMLParser
 from ftw.testbrowser.queryinfo import QueryInfo
 from ftw.testbrowser.utils import normalize_spaces
-from ftw.testbrowser.utils import parse_html
 from lxml.cssselect import CSSSelector
 from OFS.interfaces import IItem
 from operator import attrgetter
@@ -862,7 +862,9 @@ class Browser(object):
         :param html: The HTML to parse (default: current response).
         :type html: string
         """
-        return self._load_html(html or self.contents, parse_html)
+        def parse(html):
+            return lxml.html.parse(html, TestbrowserHTMLParser(encoding=self.encoding))
+        return self._load_html(html or self.contents, parse)
 
     def parse_as_xml(self, xml=None):
         """Parse the response document with the XML parser.
@@ -1033,7 +1035,7 @@ class Browser(object):
 
         return html
 
-    def _load_html(self, html, parser=parse_html):
+    def _load_html(self, html, parser):
         self.form_files = {}
 
         if hasattr(html, 'seek'):

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -425,6 +425,29 @@ class TestBrowserRequests(BrowserTestCase):
         self.assertEquals('<!DOCTYPE', browser.contents.strip()[:9])
 
     @browsing
+    def test_partial_template_encoding_utf8(self, browser):
+        """Plone may choose a different encoding (such as ISO-8859-15) when there is
+        neither an encoding specificed in the response header nor in an xml node.
+        The testbrowser must then adapt and use the correct encoding.
+        """
+        browser.open(view='test-partial?set_utf8_encoding=True')
+        self.assertEquals('utf-8', browser.encoding.lower())
+        self.assertEquals([u'Bj\xf6rn', u'G\xfcnther', u'A\xefda'],
+                          browser.css('#names li').text)
+
+    @browsing
+    def test_partial_template_encoding_latin9(self, browser):
+        """Plone may choose a different encoding (such as ISO-8859-15) when there is
+        neither an encoding specificed in the response header nor in an xml node.
+        The testbrowser must then adapt and use the correct encoding.
+        """
+        browser.open(view='test-partial')
+        # iso-8859-15 is the ZPublisher standard encoding for HTTPResponses
+        self.assertEquals('iso-8859-15', browser.encoding.lower())
+        self.assertEquals([u'Bj\xf6rn', u'G\xfcnther', u'A\xefda'],
+                          browser.css('#names li').text)
+
+    @browsing
     def test_send_authenticator(self, browser):
         class ProtectedView(BrowserView):
             def __call__(self):

--- a/ftw/testbrowser/tests/views/configure.zcml
+++ b/ftw/testbrowser/tests/views/configure.zcml
@@ -94,4 +94,12 @@
         permission="zope.Public"
         />
 
+    <browser:page
+        name="test-partial"
+        template="test-partial.pt"
+        class=".views.TestPartialView"
+        for="*"
+        permission="zope.Public"
+        />
+
 </configure>

--- a/ftw/testbrowser/tests/views/test-partial.pt
+++ b/ftw/testbrowser/tests/views/test-partial.pt
@@ -1,0 +1,5 @@
+<ul id="names">
+  <li>Björn</li>
+  <li>Günther</li>
+  <li>Aïda</li>
+</ul>

--- a/ftw/testbrowser/tests/views/views.py
+++ b/ftw/testbrowser/tests/views/views.py
@@ -94,3 +94,12 @@ class TestRedirectLoop(BrowserView):
 
     def __call__(self):
         return self.request.response.redirect(self.request['ACTUAL_URL'])
+
+
+class TestPartialView(BrowserView):
+
+    def __call__(self):
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
+        if self.request.get('set_utf8_encoding'):
+            self.request.response.setHeader('content-type', 'text/html; charset=utf-8')
+        return super(TestPartialView, self).__call__()

--- a/ftw/testbrowser/utils.py
+++ b/ftw/testbrowser/utils.py
@@ -1,15 +1,9 @@
-from ftw.testbrowser.parser import TestbrowserHTMLParser
 from zope.interface.declarations import implementedBy
-import lxml
 import re
 
 
 def normalize_spaces(text):
     return re.sub(r'[\s\xa0]{1,}', ' ', text).strip()
-
-
-def parse_html(html):
-    return lxml.html.parse(html, TestbrowserHTMLParser())
 
 
 def copy_docs_from_interface(klass):


### PR DESCRIPTION
This pull request should improve the encoding situation in testbrowser a bit.

~~The problem is that we use `lxml` to parse HTML. XML must have an encoding node, therefore `lxml` expects that node and reads the encoding from there. But HTML does not necesserily have an encoding node, especially when only a partial is sent, not a full HTML document.~~

~~`lxml.html` sometimes messes up the encoding when no node declares the encoding. But it is hard to tell it the correct encoding, which we usually know from the `content-type` HTTP response header.~~

Changes:

1. Let the parser used for `lxml.html` know the encoding from the `content-type` header. This makes the situation better when the document is encoded in `utf-8`. However, it does not really work with encodings such as `ISO-8859-15`/`latin-9` (default Zope encoding).

~~2. Therefore the testbrowser now prints a warning whenever a response is not `utf-8`. The warning can be disabled with an environment variable when it is too annoying.~~