### PR TITLE
Add an `allow_redirects` property to `browser` for being able to block following redirects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.30.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add an `allow_redirects` property to `browser` for being able to block
+  following redirects. [Rotonen]
 
 
 1.30.0 (2018-08-03)

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -483,6 +483,36 @@ Re-parsing with another parser:
 .. seealso:: :py:mod:`ftw.testbrowser.core.Browser.parse`
 
 
+HTTP requests
+===============
+
+`ftw.testbrowser` also supports not following redirects. This is useful for
+testing the bodies of redirect responses or inspecting `Location` headers.
+
+This is currently not implemented for mechanize.
+
+.. code:: py
+
+    from ftw.testbrowser import browsing
+    from unittest2 import TestCase
+
+
+    class TestRedirects(TestCase):
+
+      @browsing
+      def test_redirects_are_followed_automatically(self, browser):
+          browser.open(view='test-redirect-to-portal')
+          self.assertEquals(self.portal.absolute_url(), browser.url)
+          self.assertEquals(('listing_view', 'plone-site'), plone.view_and_portal_type())
+
+      @browsing
+      def test_redirect_following_can_be_prevented(self, browser):
+          browser.allow_redirects = False
+          browser.open(view='test-redirect-to-portal')
+          self.assertEquals('/'.join((self.portal.absolute_url(), 'test-redirect-to-portal')), browser.url)
+          self.assertEquals((None, None), plone.view_and_portal_type())
+
+
 WebDAV requests
 ===============
 

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -136,6 +136,7 @@ class Browser(object):
         self.previous_url = None
         self.form_files = {}
         self.session_headers = []
+        self.allow_redirects = True
         self._status_code = None
         self._status_reason = None
 

--- a/ftw/testbrowser/drivers/mechdriver.py
+++ b/ftw/testbrowser/drivers/mechdriver.py
@@ -44,8 +44,10 @@ class MechanizeDriver(object):
 
     @remembering_for_reload
     @isolated
-    def make_request(self, method, url, data=None, headers=None,
-                     referer_url=None):
+    def make_request(self, method, url, data=None, headers=None, referer_url=None):
+        if not self.browser.allow_redirects:
+            raise ValueError('The mechanize driver does not support changing the redirect following behaviour.')
+
         data = self._prepare_post_data(data)
         request = Request(url, data)
         if referer_url:

--- a/ftw/testbrowser/drivers/requestsdriver.py
+++ b/ftw/testbrowser/drivers/requestsdriver.py
@@ -48,7 +48,7 @@ class RequestsDriver(object):
 
         try:
             self.response = self.requests_session.request(
-                method, url, data=data, headers=headers)
+                method, url, data=data, headers=headers, allow_redirects=self.browser.allow_redirects)
         except requests.exceptions.TooManyRedirects, exc:
             raise RedirectLoopException(exc.request.url)
 

--- a/ftw/testbrowser/drivers/traversaldriver.py
+++ b/ftw/testbrowser/drivers/traversaldriver.py
@@ -249,7 +249,7 @@ class TraversalDriver(object):
         self.response = response
         self.current_url = prepared_request.url
 
-        if self.response.status in (301, 302, 303):
+        if self.browser.allow_redirects and self.response.status in (301, 302, 303):
             return self._follow_redirects(method, data, headers)
         else:
             self._unzip_gzip_response()

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -391,6 +391,14 @@ class TestBrowserRequests(BrowserTestCase):
         self.assertEquals(('listing_view', 'plone-site'),
                           plone.view_and_portal_type())
 
+    @skip_driver(LIB_MECHANIZE, 'Changing redirect following behavior is not supported.')
+    @browsing
+    def test_redirect_following_can_be_prevented(self, browser):
+        browser.allow_redirects = False
+        browser.open(view='test-redirect-to-portal')
+        self.assertEquals('/'.join((self.portal.absolute_url(), 'test-redirect-to-portal')), browser.url)
+        self.assertEquals((None, None), plone.view_and_portal_type())
+
     @browsing
     def test_redirect_loops_are_interrupted(self, browser):
         with self.assertRaises(RedirectLoopException) as cm:


### PR DESCRIPTION
* Not implemented for mechanize
* Used the naming from requests