### PR TITLE
Add support for Plone 5.2

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,21 @@ Changelog
 =========
 
 
-1.30.2 (unreleased)
--------------------
+2.0.0 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Add support for Plone 5.2. [buchi]
+
+- Make Traversal and Mechanize drivers optional as the underlying libraries are
+  no longer available in Zope 4 (Plone 5.2). [buchi]
+
+- No longer use plone.formwidget.autocomplete and plone.formwidget.contenttree
+  in tests with Plone 5 and later. [buchi]
+
+- Implement AjaxSelectWidget and improve RelatedItemsWidget. [buchi]
+
+- Modernize z3c form used in test by using directives to setup widgets and
+  removing form wrapper. [buchi]
 
 
 1.30.1 (2019-01-25)

--- a/ftw/testbrowser/compat.py
+++ b/ftw/testbrowser/compat.py
@@ -1,0 +1,9 @@
+import pkg_resources
+
+
+try:
+    pkg_resources.get_distribution('Zope')
+except pkg_resources.DistributionNotFound:
+    HAS_ZOPE4 = False
+else:
+    HAS_ZOPE4 = True

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -272,9 +272,13 @@ class Browser(object):
             raise HTTPClientError(self.status_code, self.status_reason)
         elif 500 <= self.status_code < 600:
             raise HTTPServerError(self.status_code, self.status_reason)
-        elif urlparse.urlparse(self.url).path.split('/')[-1] == 'require_login':
-            # Plone has redirected to "require_login", indicating that the user
-            # has insufficient privileges.
+        elif (
+            '/login?came_from=' in self.url
+            or '/require_login?came_from=' in self.url
+            or '/insufficient-privileges' in self.url
+        ):
+            # Plone has redirected to the login form or a page indicating that
+            # the user has insufficient privileges.
             raise InsufficientPrivileges(self.status_code, self.status_reason)
 
     def on(self, url_or_object=None, data=None, view=None, library=None):

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -1,10 +1,11 @@
 from Acquisition import aq_chain
 from contextlib import contextmanager
 from copy import deepcopy
-from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
-from ftw.testbrowser.drivers.requestsdriver import RequestsDriver
-from ftw.testbrowser.drivers.staticdriver import StaticDriver
-from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
+from ftw.testbrowser.drivers import DRIVER_FACTORIES
+from ftw.testbrowser.drivers import LIB_MECHANIZE
+from ftw.testbrowser.drivers import LIB_REQUESTS
+from ftw.testbrowser.drivers import LIB_STATIC
+from ftw.testbrowser.drivers import LIB_TRAVERSAL  # noqa
 from ftw.testbrowser.exceptions import AmbiguousFormFields
 from ftw.testbrowser.exceptions import BlankPage
 from ftw.testbrowser.exceptions import BrowserNotSetUpException
@@ -48,29 +49,6 @@ except pkg_resources.DistributionNotFound:
 else:
     from plone.app.testing import TEST_USER_NAME
     from plone.app.testing import TEST_USER_PASSWORD
-
-
-#: Constant for choosing the mechanize library (interally dispatched requests)
-LIB_TRAVERSAL = TraversalDriver.LIBRARY_NAME
-
-#: Constant for choosing the requests library (actual requests)
-LIB_REQUESTS = RequestsDriver.LIBRARY_NAME
-
-#: Constant for choosing the mechanize library (interally dispatched requests)
-LIB_MECHANIZE = MechanizeDriver.LIBRARY_NAME
-
-#: Constant for choosing the static driver.
-LIB_STATIC = StaticDriver.LIBRARY_NAME
-
-
-#: Mapping of driver library constants to its factories.
-#: This design is historical so that the library constants
-#: keep working. This mapping may be monkey patched.
-DRIVER_FACTORIES = {
-    TraversalDriver.LIBRARY_NAME: TraversalDriver,
-    MechanizeDriver.LIBRARY_NAME: MechanizeDriver,
-    RequestsDriver.LIBRARY_NAME: RequestsDriver,
-    StaticDriver.LIBRARY_NAME: StaticDriver}
 
 
 class Browser(object):
@@ -156,7 +134,7 @@ class Browser(object):
         if self.request_library is None:
             if self.default_driver is not None:
                 self.request_library = self.default_driver
-            elif self.next_app is None:
+            elif self.next_app is None or LIB_MECHANIZE is None:
                 self.request_library = LIB_REQUESTS
             else:
                 self.request_library = LIB_MECHANIZE

--- a/ftw/testbrowser/drivers/__init__.py
+++ b/ftw/testbrowser/drivers/__init__.py
@@ -1,0 +1,33 @@
+from ftw.testbrowser.compat import HAS_ZOPE4
+from ftw.testbrowser.drivers.requestsdriver import RequestsDriver
+from ftw.testbrowser.drivers.staticdriver import StaticDriver
+
+#: Constant for choosing the requests library (actual requests)
+LIB_REQUESTS = RequestsDriver.LIBRARY_NAME
+
+#: Constant for choosing the static driver.
+LIB_STATIC = StaticDriver.LIBRARY_NAME
+
+DRIVER_FACTORIES = {
+    RequestsDriver.LIBRARY_NAME: RequestsDriver,
+    StaticDriver.LIBRARY_NAME: StaticDriver,
+}
+
+if not HAS_ZOPE4:
+    from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
+    from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
+
+    #: Constant for choosing the mechanize library (interally dispatched requests)
+    LIB_TRAVERSAL = TraversalDriver.LIBRARY_NAME
+
+    #: Constant for choosing the mechanize library (interally dispatched requests)
+    LIB_MECHANIZE = MechanizeDriver.LIBRARY_NAME
+
+    DRIVER_FACTORIES.update({
+        TraversalDriver.LIBRARY_NAME: TraversalDriver,
+        MechanizeDriver.LIBRARY_NAME: MechanizeDriver,
+    })
+
+else:
+    LIB_TRAVERSAL = None
+    LIB_MECHANIZE = None

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -13,6 +13,7 @@ from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PLONE_ZSERVER
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
+from Products.CMFPlone.utils import getFSVersionTuple
 from zope.configuration import xmlconfig
 
 
@@ -47,8 +48,10 @@ class BrowserLayer(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.testbrowser.tests:dxtype')
-        applyProfile(portal, 'plone.formwidget.autocomplete:default')
         applyProfile(portal, 'plone.app.contenttypes:default')
+        applyProfile(portal, 'collective.z3cform.datagridfield:default')
+        if getFSVersionTuple() < (5, 0):
+            applyProfile(portal, 'plone.formwidget.autocomplete:default')
         register_dx_content_builders(force=True)
 
 

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -5,6 +5,7 @@ from ftw.builder.testing import set_builder_session_factory
 from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
 from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
+from ftw.testbrowser.compat import HAS_ZOPE4
 from ftw.testing import FTWIntegrationTesting
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
@@ -27,6 +28,10 @@ class BrowserLayer(PloneSandboxLayer):
             '  <includePluginsOverrides package="plone" />'
             '</configure>',
             context=configurationContext)
+
+        if HAS_ZOPE4:
+            import Products.SiteErrorLog
+            self.loadZCML(package=Products.SiteErrorLog)
 
         import ftw.testbrowser.tests
         xmlconfig.file('profiles/dxtype.zcml',

--- a/ftw/testbrowser/tests/alldrivers.py
+++ b/ftw/testbrowser/tests/alldrivers.py
@@ -14,12 +14,19 @@ def all_drivers(testcase):
     """
 
     module = sys.modules[testcase.__module__]
-    drivers = (
-        ('Mechanize', MECHANIZE_TESTING, LIB_MECHANIZE),
+    drivers = [
         ('Requests', REQUESTS_TESTING, LIB_REQUESTS),
-        ('Traversal', TRAVERSAL_TESTING, LIB_TRAVERSAL),
-        ('TraversalIntegration', TRAVERSAL_INTEGRATION_TESTING, LIB_TRAVERSAL),
-    )
+    ]
+
+    if LIB_MECHANIZE is not None:
+        drivers.append(('Mechanize', MECHANIZE_TESTING, LIB_MECHANIZE))
+
+    if LIB_TRAVERSAL is not None:
+        drivers.extend([
+            ('Traversal', TRAVERSAL_TESTING, LIB_TRAVERSAL),
+            ('TraversalIntegration', TRAVERSAL_INTEGRATION_TESTING, LIB_TRAVERSAL),
+        ])
+
     testcase._testbrowser_abstract_testclass = True
 
     for postfix, layer, constant in drivers:

--- a/ftw/testbrowser/tests/interfaces.py
+++ b/ftw/testbrowser/tests/interfaces.py
@@ -1,12 +1,15 @@
-from plone.formwidget.contenttree import ObjPathSourceBinder
+from Products.CMFPlone.utils import getFSVersionTuple
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope.interface import Interface
 
 
-page_source = ObjPathSourceBinder(
-    portal_type="Document",
-)
+if getFSVersionTuple() >= (5, 0):
+    from plone.app.vocabularies.catalog import CatalogSource
+    page_source = CatalogSource(portal_type='Document')
+else:
+    from plone.formwidget.contenttree import ObjPathSourceBinder
+    page_source = ObjPathSourceBinder(portal_type="Document")
 
 
 class IDXTypeSchema(Interface):

--- a/ftw/testbrowser/tests/test_defaultdriver.py
+++ b/ftw/testbrowser/tests/test_defaultdriver.py
@@ -1,33 +1,39 @@
 from ftw.testbrowser import Browser
 from ftw.testbrowser import browsing
+from ftw.testbrowser.compat import HAS_ZOPE4
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.testing import DEFAULT_TESTING
 from ftw.testbrowser.testing import REQUESTS_TESTING
 from ftw.testbrowser.tests import BrowserTestCase
+from unittest import skipIf
 
 
 class TestDefaultDriver(BrowserTestCase):
     layer = DEFAULT_TESTING
 
-    def test_library_constants_without_zopeapp(self):
+    def test_lib_requests_without_zopeapp(self):
         browser = Browser()
-
         browser.default_driver = LIB_REQUESTS
         with browser:
             self.assertEquals(LIB_REQUESTS, browser.get_driver().LIBRARY_NAME)
 
+    @skipIf(HAS_ZOPE4, 'Mechanize is not available for Zope 4')
+    def test_lib_mechanize_without_zopeapp(self):
+        browser = Browser()
         browser.default_driver = LIB_MECHANIZE
         with browser:
             self.assertEquals(LIB_MECHANIZE, browser.get_driver().LIBRARY_NAME)
 
-    def test_library_constants_with_zopeapp(self):
+    def test_lib_requests_with_zopeapp(self):
         browser = Browser()
-
         browser.default_driver = LIB_REQUESTS
         with browser(self.layer['app']):
             self.assertEquals(LIB_REQUESTS, browser.get_driver().LIBRARY_NAME)
 
+    @skipIf(HAS_ZOPE4, 'Mechanize is not available for Zope 4')
+    def test_lib_mechanize_with_zopeapp(self):
+        browser = Browser()
         browser.default_driver = LIB_MECHANIZE
         with browser(self.layer['app']):
             self.assertEquals(LIB_MECHANIZE, browser.get_driver().LIBRARY_NAME)
@@ -36,22 +42,28 @@ class TestDefaultDriver(BrowserTestCase):
 class TestSwitchToRequestDriver(BrowserTestCase):
     layer = REQUESTS_TESTING
 
+    @skipIf(HAS_ZOPE4, 'Mechanize is not available for Zope 4')
     @browsing
-    def test_open_supports_choosing_library_when_doing_request(self, browser):
+    def test_open_supports_choosing_mechanize_when_doing_request(self, browser):
         browser.open(library=LIB_MECHANIZE)
         self.assertEquals('MechanizeDriver',
                           type(browser.get_driver()).__name__)
 
+    @browsing
+    def test_open_supports_choosing_requests_when_doing_request(self, browser):
         browser.open(library=LIB_REQUESTS)
         self.assertEquals('RequestsDriver',
                           type(browser.get_driver()).__name__)
 
+    @skipIf(HAS_ZOPE4, 'Mechanize is not available for Zope 4')
     @browsing
-    def test_visit_supports_choosing_library_when_doing_request(self, browser):
+    def test_visit_supports_choosing_mechanize_when_doing_request(self, browser):
         browser.visit(library=LIB_MECHANIZE)
         self.assertEquals('MechanizeDriver',
                           type(browser.get_driver()).__name__)
 
+    @browsing
+    def test_visit_supports_choosing_requests_when_doing_request(self, browser):
         browser.visit(library=LIB_REQUESTS)
         self.assertEquals('RequestsDriver',
                           type(browser.get_driver()).__name__)

--- a/ftw/testbrowser/tests/test_driver_layers.py
+++ b/ftw/testbrowser/tests/test_driver_layers.py
@@ -2,14 +2,17 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser import MECHANIZE_BROWSER_FIXTURE
 from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
+from ftw.testbrowser.compat import HAS_ZOPE4
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.core import LIB_REQUESTS
 from ftw.testbrowser.core import LIB_TRAVERSAL
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
+from unittest import skipIf
 from unittest2 import TestCase
 
 
+@skipIf(HAS_ZOPE4, 'Mechanize is not available for Zope 4')
 class TestMechanizeFixture(TestCase):
 
     layer = FunctionalTesting(
@@ -34,6 +37,7 @@ class TestRequestsFixture(TestCase):
         self.assertEquals(LIB_REQUESTS, browser.get_driver().LIBRARY_NAME)
 
 
+@skipIf(HAS_ZOPE4, 'Traversal is not available for Zope 4')
 class TestTraversalFixture(TestCase):
 
     layer = FunctionalTesting(

--- a/ftw/testbrowser/tests/test_drivers_mechdriver.py
+++ b/ftw/testbrowser/tests/test_drivers_mechdriver.py
@@ -1,9 +1,16 @@
-from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
+from ftw.testbrowser.compat import HAS_ZOPE4
 from ftw.testbrowser.interfaces import IDriver
+from unittest import skipIf
 from unittest2 import TestCase
 from zope.interface.verify import verifyClass
 
+if not HAS_ZOPE4:
+    from ftw.testbrowser.drivers.mechdriver import MechanizeDriver
+else:
+    MechanizeDriver = None
 
+
+@skipIf(HAS_ZOPE4, 'Mechanize is not available for Zope 4')
 class TestMechanizeDriverImplementation(TestCase):
 
     def test_implements_interface(self):

--- a/ftw/testbrowser/tests/test_drivers_traversaldriver.py
+++ b/ftw/testbrowser/tests/test_drivers_traversaldriver.py
@@ -1,16 +1,23 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
+from ftw.testbrowser.compat import HAS_ZOPE4
 from ftw.testbrowser.interfaces import IDriver
 from ftw.testbrowser.testing import TRAVERSAL_TESTING
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests import IS_PLONE_4
 from plone.app.testing import SITE_OWNER_NAME
 from plone.registry.interfaces import IRegistry
+from unittest import skipIf
 from zope.component import getUtility
 from zope.interface.verify import verifyClass
 import transaction
 
+if not HAS_ZOPE4:
+    from ftw.testbrowser.drivers.traversaldriver import TraversalDriver
+else:
+    TraversalDriver = None
 
+
+@skipIf(HAS_ZOPE4, 'Traversal is not available for Zope 4')
 class TestTraversalDriverImplementation(BrowserTestCase):
     layer = TRAVERSAL_TESTING
 

--- a/ftw/testbrowser/tests/test_file_uploads.py
+++ b/ftw/testbrowser/tests/test_file_uploads.py
@@ -102,6 +102,7 @@ class TestFileUploadsArchetypes(TestCase):
             ('attachment; filename="%s"' % filename,
              'attachment; filename*=UTF-8\'\'%s' % filename))
         self.assertIn(browser.headers.get('Content-Type'), (
+            '%s; charset=utf-8' % content_type,  # Zope 4
             '%s; charset=iso-8859-15' % content_type,  # mechanize download
             content_type,  # requests lib download
         ))

--- a/ftw/testbrowser/tests/test_forms.py
+++ b/ftw/testbrowser/tests/test_forms.py
@@ -42,23 +42,25 @@ class TestBrowserForms(BrowserTestCase):
     @browsing
     def test_fill_field_by_name(self, browser):
         browser.open(view='login_form')
-        self.assertEquals(u'', browser.forms['login_form'].values['__ac_name'])
+        login_form = browser.find_form_by_field('__ac_name')
+        self.assertEquals(u'', login_form.values['__ac_name'])
 
         browser.fill({'__ac_name': 'hugo.boss'})
-        self.assertEquals(u'hugo.boss', browser.forms['login_form'].values['__ac_name'])
+        self.assertEquals(u'hugo.boss', login_form.values['__ac_name'])
 
     @browsing
     def test_fill_field_by_label(self, browser):
         browser.open(view='login_form')
-        self.assertEquals(u'', browser.forms['login_form'].values['__ac_name'])
+        login_form = browser.find_form_by_field('__ac_name')
+        self.assertEquals(u'', login_form.values['__ac_name'])
 
         browser.fill({'Login Name': 'hugo.boss'})
-        self.assertEquals(u'hugo.boss', browser.forms['login_form'].values['__ac_name'])
+        self.assertEquals(u'hugo.boss', login_form.values['__ac_name'])
 
     @browsing
     def test_forms_are_not_wrapped_multiple_times(self, browser):
         browser.open(view='login_form')
-        form = browser.forms['login_form']
+        form = browser.find_form_by_field('__ac_name')
         self.assertEquals(Form, type(form))
         self.assertEquals(lxml.html.FormElement, type(form.node))
 

--- a/ftw/testbrowser/tests/test_log.py
+++ b/ftw/testbrowser/tests/test_log.py
@@ -27,15 +27,11 @@ class TestExceptionLogger(BrowserTestCase):
         # The output starts with a random error_log id => strip it.
         self.assertTrue(output, 'No output in stderr')
         output = output.split(' ', 1)[1]
-        self.assertEquals(
-            '{}/failing-view\n'.format(self.portal.absolute_url()) +
-            'Traceback (innermost last):\n'
-            '  Module ZPublisher.Publish, line 138, in publish\n'
-            '  Module ZPublisher.mapply, line 77, in mapply\n'
-            '  Module ZPublisher.Publish, line 48, in call_object\n'
-            '  Module ftw.testbrowser.tests.test_log, line 18, in __call__\n'
-            'ValueError: The value is wrong.',
-            output)
+        expected_start = '{}/failing-view\n'.format(
+            self.portal.absolute_url()) + 'Traceback (innermost last):\n'
+        expected_end = 'ValueError: The value is wrong.'
+        self.assertTrue(output.startswith(expected_start), 'Unexpected traceback')
+        self.assertTrue(output.endswith(expected_end), 'Unexpected traceback')
 
     @browsing
     def test_no_exceptions_logged_when_errors_expected(self, browser):

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -456,8 +456,13 @@ class TestBrowserRequests(BrowserTestCase):
         The testbrowser must then adapt and use the correct encoding.
         """
         browser.open(view='test-partial')
-        # iso-8859-15 is the ZPublisher standard encoding for HTTPResponses
-        self.assertEquals('iso-8859-15', browser.encoding.lower())
+
+        default_encoding = 'iso-8859-15'
+        # Plone 5.1.6 (plone.testing 4.3.3) sets ZPublisher encoding to UTF-8
+        if getFSVersionTuple() >= (5, 1, 6):
+            default_encoding = 'utf-8'
+
+        self.assertEquals(default_encoding, browser.encoding.lower())
         self.assertEquals([u'Bj\xf6rn', u'G\xfcnther', u'A\xefda'],
                           browser.css('#names li').text)
 

--- a/ftw/testbrowser/tests/test_requests.py
+++ b/ftw/testbrowser/tests/test_requests.py
@@ -18,11 +18,17 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import getFSVersionTuple
 from StringIO import StringIO
 from unittest import skipUnless
 from zExceptions import BadRequest
 from zope.component import getUtility
 from zope.publisher.browser import BrowserView
+
+
+LOGIN_FORM_ID = 'login_form'
+if getFSVersionTuple() >= (5, 2):
+    LOGIN_FORM_ID = 'form-1'
 
 
 @all_drivers
@@ -135,12 +141,12 @@ class TestBrowserRequests(BrowserTestCase):
         browser.fill({'Login Name': 'userid'})
         self.assertDictContainsSubset(
             {'__ac_name': 'userid'},
-            dict(browser.forms['login_form'].values))
+            dict(browser.forms[LOGIN_FORM_ID].values))
 
         browser.on(view='login_form')
         self.assertDictContainsSubset(
             {'__ac_name': 'userid'},
-            dict(browser.forms['login_form'].values),
+            dict(browser.forms[LOGIN_FORM_ID].values),
             'Seems that the page was reloaded when using browser.on'
             ' even though we are already on this page.')
 
@@ -273,12 +279,12 @@ class TestBrowserRequests(BrowserTestCase):
         browser.fill({'Login Name': 'the-user-id'})
         self.assertDictContainsSubset(
             {'__ac_name': 'the-user-id'},
-            dict(browser.forms['login_form'].values))
+            dict(browser.forms[LOGIN_FORM_ID].values))
 
         browser.reload()
         self.assertDictContainsSubset(
             {'__ac_name': ''},
-            dict(browser.forms['login_form'].values))
+            dict(browser.forms[LOGIN_FORM_ID].values))
 
     @browsing
     def test_reload_POST_reqest(self, browser):

--- a/ftw/testbrowser/tests/test_webdav_requests.py
+++ b/ftw/testbrowser/tests/test_webdav_requests.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.compat import HAS_ZOPE4
 from ftw.testbrowser.core import LIB_MECHANIZE
 from ftw.testbrowser.exceptions import NoWebDAVSupport
 from ftw.testbrowser.pages import plone
@@ -10,8 +11,10 @@ from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.alldrivers import skip_driver
 from lxml import etree
 from plone.app.testing import SITE_OWNER_NAME
+from unittest import skipIf
 
 
+@skipIf(HAS_ZOPE4, 'WebDAV is no longer available in Zope 4')
 @all_drivers
 class TestWebdavRequests(BrowserTestCase):
 
@@ -65,6 +68,7 @@ class TestWebdavRequests(BrowserTestCase):
         self.assertEqual("Test Token", browser.document.find('.//{DAV:}href').text)
 
 
+@skipIf(HAS_ZOPE4, 'WebDAV is no longer available in Zope 4')
 class TestNoZserverWebdavRequests(BrowserTestCase):
     layer = MECHANIZE_TESTING
 

--- a/ftw/testbrowser/tests/test_widgets_contenttree.py
+++ b/ftw/testbrowser/tests/test_widgets_contenttree.py
@@ -4,8 +4,12 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from plone.app.testing import SITE_OWNER_NAME
+from Products.CMFPlone.utils import getFSVersionTuple
+from unittest import skipIf
 
 
+@skipIf(getFSVersionTuple() >= (5, 0),
+        'The content tree widget is only for Plone 4.3')
 @all_drivers
 class TestContentTreeWidget(BrowserTestCase):
 

--- a/ftw/testbrowser/tests/test_widgets_relateditems.py
+++ b/ftw/testbrowser/tests/test_widgets_relateditems.py
@@ -1,0 +1,39 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests.alldrivers import all_drivers
+from plone.app.testing import SITE_OWNER_NAME
+from plone.uuid.interfaces import IUUID
+from Products.CMFPlone.utils import getFSVersionTuple
+from unittest import skipIf
+
+
+@skipIf(getFSVersionTuple() < (5, 0),
+        'The related items widget requires Plone 5 or later')
+@all_drivers
+class TestRelatedItemsWidget(BrowserTestCase):
+
+    def setUp(self):
+        super(TestRelatedItemsWidget, self).setUp()
+        self.grant('Manager')
+
+    @browsing
+    def test_selecting_object(self, browser):
+        foo = create(Builder('document').titled(u'Foo'))
+        bar = create(Builder('document').titled(u'Bar'))
+
+        browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
+        browser.fill({'Documents': (foo, bar)})
+        browser.find('Submit').click()
+        self.assertEquals({u'documents': [IUUID(foo), IUUID(bar)]},
+                          browser.json)
+
+    @browsing
+    def test_querying_objects(self, browser):
+        doc = create(Builder('document').titled(u'The Document'))
+
+        browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
+
+        self.assertEquals([[IUUID(doc), u'The Document']],
+                          browser.find('Documents').query('doc'))

--- a/ftw/testbrowser/tests/views/configure.zcml
+++ b/ftw/testbrowser/tests/views/configure.zcml
@@ -62,7 +62,7 @@
 
     <browser:page
         name="test-z3cform-shopping"
-        class=".z3cform.ShoppingView"
+        class=".z3cform.ShoppingForm"
         for="*"
         permission="cmf.ModifyPortalContent"
         />

--- a/ftw/testbrowser/tests/views/z3cform.py
+++ b/ftw/testbrowser/tests/views/z3cform.py
@@ -3,27 +3,37 @@ from collective.z3cform.datagridfield import DictRow
 from datetime import date
 from datetime import datetime
 from OFS.interfaces import IItem
-from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
-from plone.formwidget.contenttree import MultiContentTreeFieldWidget
-from plone.formwidget.contenttree import PathSourceBinder
-from plone.formwidget.contenttree import UUIDSourceBinder
+from plone.app.vocabularies.catalog import CatalogSource
+from plone.autoform import directives
+from plone.autoform.form import AutoExtensibleForm
 from plone.i18n.normalizer import idnormalizer
+from plone.supermodel import model
 from plone.uuid.interfaces import IUUID
-from plone.z3cform.layout import FormWrapper
+from Products.CMFPlone.utils import getFSVersionTuple
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.browser.radio import RadioFieldWidget
 from z3c.form.button import buttonAndHandler
-from z3c.form.field import Fields
 from z3c.form.form import Form
 from z3c.formwidget.query.interfaces import IQuerySource
 from z3c.relationfield import RelationChoice
+from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.interface import implements
-from zope.interface import Interface
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 import json
+
+PLONE5 = getFSVersionTuple() >= (5, 0)
+
+if PLONE5:
+    from plone.app.z3cform.widget import AjaxSelectFieldWidget
+    from plone.app.z3cform.widget import RelatedItemsFieldWidget
+else:
+    from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
+    from plone.formwidget.contenttree import MultiContentTreeFieldWidget
+    from plone.formwidget.contenttree import PathSourceBinder
+    from plone.formwidget.contenttree import UUIDSourceBinder
 
 
 class PaymentVocabulary(SimpleVocabulary):
@@ -50,7 +60,7 @@ def make_term_from_title(title):
     return SimpleTerm(token, token, title)
 
 
-class ICakeSchema(Interface):
+class ICakeSchema(model.Schema):
     quantity = schema.Int(
         title=u'Quantity',
         required=True,
@@ -74,15 +84,24 @@ class ICakeSchema(Interface):
         required=False,
     )
 
-    reference = RelationChoice(
-        title=u'Reference',
-        source=UUIDSourceBinder(),
-        required=False,
-    )
+    if PLONE5:
+        directives.widget(reference=RelatedItemsFieldWidget)
+        reference = RelationChoice(
+            title=u'Reference',
+            source=CatalogSource(),
+            required=False,
+        )
+    else:
+        reference = RelationChoice(
+            title=u'Reference',
+            source=UUIDSourceBinder(),
+            required=False,
+        )
 
 
-class IShoppingFormSchema(Interface):
+class IShoppingFormSchema(model.Schema):
 
+    directives.widget(fruits=CheckBoxFieldWidget)
     fruits = schema.List(
         title=u'Fruits',
         value_type=schema.Choice(
@@ -92,11 +111,20 @@ class IShoppingFormSchema(Interface):
                  SimpleTerm(u'orange', u'orange', u'Orange')])),
         required=False)
 
+    directives.widget(bag=RadioFieldWidget)
     bag = schema.List(
         title=u'Bag',
         value_type=schema.Choice([u'plastic bag', u'paper bag']),
         required=False)
 
+    if PLONE5:
+        directives.widget(
+            'payment',
+            AjaxSelectFieldWidget,
+            vocabulary='test-z3cform-payment-vocabulary'
+        )
+    else:
+        directives.widget(payment=AutocompleteMultiFieldWidget)
     payment = schema.List(
         title=u'Payment',
         value_type=schema.Choice(
@@ -111,11 +139,22 @@ class IShoppingFormSchema(Interface):
         title=u'Day of payment',
         required=False)
 
-    documents = schema.List(
-        title=u'Documents',
-        value_type=schema.Choice(
-            source=PathSourceBinder(portal_type='Document')))
+    if PLONE5:
+        directives.widget(documents=RelatedItemsFieldWidget)
+        documents = RelationList(
+            title=u'Documents',
+            value_type=RelationChoice(
+                source=CatalogSource(portal_type='Document'),
+                ),
+            required=False)
+    else:
+        directives.widget(documents=MultiContentTreeFieldWidget)
+        documents = schema.List(
+            title=u'Documents',
+            value_type=schema.Choice(
+                source=PathSourceBinder(portal_type='Document')))
 
+    directives.widget(cakes=DataGridFieldFactory)
     cakes = schema.List(
         title=u'Cakes',
         value_type=DictRow(title=u'Cake', schema=ICakeSchema),
@@ -124,22 +163,14 @@ class IShoppingFormSchema(Interface):
     )
 
 
-class ShoppingForm(Form):
+class ShoppingForm(AutoExtensibleForm, Form):
     label = u'Shopping'
     ignoreContext = True
-    fields = Fields(IShoppingFormSchema)
+    schema = IShoppingFormSchema
 
     def __init__(self, *args, **kwargs):
         super(ShoppingForm, self).__init__(*args, **kwargs)
         self.result_data = None
-
-    def update(self):
-        self.fields['fruits'].widgetFactory = CheckBoxFieldWidget
-        self.fields['bag'].widgetFactory = RadioFieldWidget
-        self.fields['payment'].widgetFactory = AutocompleteMultiFieldWidget
-        self.fields['documents'].widgetFactory = MultiContentTreeFieldWidget
-        self.fields['cakes'].widgetFactory = DataGridFieldFactory
-        return super(ShoppingForm, self).update()
 
     def updateWidgets(self, prefix=None):
         super(ShoppingForm, self).updateWidgets(prefix)
@@ -157,18 +188,13 @@ class ShoppingForm(Form):
                 continue
             self.result_data[key] = value
 
-
-class ShoppingView(FormWrapper):
-
-    form = ShoppingForm
-
     def render(self):
-        if self.form_instance.result_data:
+        if self.result_data:
             self.request.RESPONSE.setHeader('Content-Type', 'application/json')
             return json.dumps(self.make_json_serializable(
-                self.form_instance.result_data))
+                self.result_data))
         else:
-            return super(ShoppingView, self).render()
+            return super(ShoppingForm, self).render()
 
     def make_json_serializable(self, value):
         if isinstance(value, (datetime, date)):

--- a/ftw/testbrowser/widgets/__init__.py
+++ b/ftw/testbrowser/widgets/__init__.py
@@ -4,4 +4,5 @@ from ftw.testbrowser.widgets import sequence
 from ftw.testbrowser.widgets import autocomplete
 from ftw.testbrowser.widgets import atmultiselect
 from ftw.testbrowser.widgets import z3cchoicecollection
+from ftw.testbrowser.widgets import select
 from ftw.testbrowser.widgets import datagridwidget

--- a/ftw/testbrowser/widgets/autocomplete.py
+++ b/ftw/testbrowser/widgets/autocomplete.py
@@ -1,7 +1,6 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
 from lxml import etree
-from plone.uuid.interfaces import IUUID
 import re
 
 
@@ -89,38 +88,6 @@ class AutocompleteWidget(PloneWidget):
         for value in values:
             if hasattr(value, 'getPhysicalPath'):
                 new_values.append('/'.join(value.getPhysicalPath()))
-            else:
-                new_values.append(value)
-        return new_values
-
-
-@widget
-class PatternsLibAutocompleteWidget(PloneWidget):
-    """Represents the Autocomplete widget implemented with patternslib"""
-
-    @staticmethod
-    def match(node):
-        if not PloneWidget.match(node):
-            return False
-
-        return len(node.css('[data-pat-relateditems]')) > 0
-
-    def fill(self, values):
-        """With patternslib the Relation fields are represented as
-        input text field containing one uid, or multiple uids seperated
-        by a colon.
-        """
-        if not isinstance(values, (list, set, tuple)):
-            values = [values]
-
-        values = self._resolve_objects_to_uid(values)
-        self.css('input').first.value = ':'.join(values)
-
-    def _resolve_objects_to_uid(self, values):
-        new_values = []
-        for value in values:
-            if hasattr(value, 'getPhysicalPath'):
-                new_values.append(IUUID(value))
             else:
                 new_values.append(value)
         return new_values

--- a/ftw/testbrowser/widgets/select.py
+++ b/ftw/testbrowser/widgets/select.py
@@ -1,5 +1,7 @@
 from ftw.testbrowser.widgets.base import PloneWidget
 from ftw.testbrowser.widgets.base import widget
+from plone.uuid.interfaces import IUUID
+from urllib import quote_plus
 import json
 
 
@@ -33,3 +35,67 @@ class AjaxSelectWidget(PloneWidget):
     def pat_data(self):
         return json.loads(
             self.css('input.pat-select2')[0].node.attrib['data-pat-select2'])
+
+
+@widget
+class RelatedItemsWidget(PloneWidget):
+    """Represents the related items widget implemented with patternslib"""
+
+    @staticmethod
+    def match(node):
+        if not PloneWidget.match(node):
+            return False
+
+        return len(node.css('.pat-relateditems')) > 0
+
+    def fill(self, values):
+        """With patternslib the Relation fields are represented as
+        input text field containing one uid, or multiple uids seperated
+        by a colon.
+        """
+        if not isinstance(values, (list, set, tuple)):
+            values = [values]
+
+        values = self._resolve_objects_to_uid(values)
+
+        separator = self.pat_data()['separator']
+        self.css('input').first.value = separator.join(values)
+
+    def query(self, query_string):
+        vocabulary_url = self.pat_data()['vocabularyUrl']
+        query = {
+            "criteria": [
+                {
+                    "i": "SearchableText",
+                    "o": "plone.app.querystring.operation.string.contains",
+                    "v": "*" + query_string + "*",
+                },
+            ],
+        }
+        attributes = [
+            "UID", "Title", "portal_type", "path", "getURL", "getIcon",
+            "is_folderish", "review_state",
+        ]
+        qs = '?query={}&attributes={}'.format(
+            quote_plus(json.dumps(query, separators=(',', ':')), '*'),
+            quote_plus(json.dumps(attributes, separators=(',', ':')), '*'),
+        )
+        with self.browser.clone() as query_browser:
+            query_browser.open(vocabulary_url + qs)
+            return [
+                [item[u'UID'], item[u'Title']]
+                for item in query_browser.json[u'results']
+            ]
+
+    def _resolve_objects_to_uid(self, values):
+        new_values = []
+        for value in values:
+            if hasattr(value, 'getPhysicalPath'):
+                new_values.append(IUUID(value))
+            else:
+                new_values.append(value)
+        return new_values
+
+    def pat_data(self):
+        return json.loads(self.css(
+            'input.pat-relateditems')[0].node.attrib['data-pat-relateditems'])

--- a/ftw/testbrowser/widgets/select.py
+++ b/ftw/testbrowser/widgets/select.py
@@ -1,0 +1,35 @@
+from ftw.testbrowser.widgets.base import PloneWidget
+from ftw.testbrowser.widgets.base import widget
+import json
+
+
+@widget
+class AjaxSelectWidget(PloneWidget):
+    """Represents the ajax select widget.
+    """
+
+    @staticmethod
+    def match(node):
+        if not PloneWidget.match(node):
+            return False
+        return len(node.css('.pat-select2')) > 0
+
+    def fill(self, values):
+        if not isinstance(values, (list, set, tuple)):
+            values = [values]
+
+        separator = self.pat_data()['separator']
+        self.css('input.pat-select2')[0].value = separator.join(values)
+
+    def query(self, query_string):
+        vocabulary_url = self.pat_data()['vocabularyUrl']
+        with self.browser.clone() as query_browser:
+            query_browser.open(vocabulary_url, data={'query': query_string})
+            return [
+                [item[u'id'], item[u'text']]
+                for item in query_browser.json[u'results']
+            ]
+
+    def pat_data(self):
+        return json.loads(
+            self.css('input.pat-select2')[0].node.attrib['data-pat-select2'])

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,11 @@ tests_require = [
 
 extras_require = {
     'tests': tests_require,
-    'plone': ['plone.app.testing']}
+    'plone': ['plone.app.testing'],
+    'zope2': [
+        'mechanize',
+    ],
+}
 
 
 setup(name='ftw.testbrowser',
@@ -72,10 +76,10 @@ setup(name='ftw.testbrowser',
         'Acquisition',
         'cssselect',
         'lxml',
-        'mechanize',
         'plone.testing',
         'plone.uuid',
         'requests',
+        'requests_toolbelt',
         'setuptools',
         'zope.component',
         'zope.deprecation',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-version = '1.30.2.dev0'
+version = '2.0.0.dev0'
 
 
 tests_require = [
@@ -58,6 +58,7 @@ setup(name='ftw.testbrowser',
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.1',
+        'Framework :: Plone :: 5.2',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ tests_require = [
     'plone.app.dexterity',
     'plone.app.testing',
     'plone.dexterity',
-    'plone.formwidget.autocomplete',
-    'plone.formwidget.contenttree',
     'plone.i18n',
     'plone.z3cform',
     'transaction',
@@ -38,6 +36,10 @@ tests_require = [
 
 extras_require = {
     'tests': tests_require,
+    'tests_plone4': [
+        'plone.formwidget.autocomplete',
+        'plone.formwidget.contenttree',
+     ],
     'plone': ['plone.app.testing'],
     'zope2': [
         'mechanize',

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,7 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.testbrowser
-
+test-extras = tests,tests_plone4
 
 [versions]
 # Downgrade collective.z3cform.datagridfield, since the Version 1.3.0 seems no

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x.cfg
+    sources.cfg
+
+package-name = ftw.testbrowser


### PR DESCRIPTION
- Add support for Plone 5.2.
- Make Traversal and Mechanize drivers optional as the underlying libraries are
   no longer available in Zope 4.
- No longer use plone.formwidget.autocomplete and plone.formwidget.contenttree
   in tests with Plone 5 and later.
- Implement AjaxSelectWidget and improve RelatedItemsWidget.
- Modernize z3c form used in tests by using directives to setup widgets and
   removing form wrapper.

Python 3 support comes in a separate PR.
