### PR TITLE
Plone 5: disable resource registries (performance)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,8 @@ Changelog
 - Modernize z3c form used in test by using directives to setup widgets and
   removing form wrapper. [buchi]
 
+- Plone 5: disable resource registries in order to improve overall performance. [jone]
+
 
 1.30.1 (2019-01-25)
 -------------------

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -648,3 +648,32 @@ and asserted there.
            browser.open(view='failing')
 
        self.assertEquals('No valid value was submitted', str(cm.exception))
+
+
+Plone 5: resource registries disabled
+-------------------------------------
+
+In Plone 5, the resource registries are cooked when the resource registry viewlets are rendered.
+Cooking the bundles takes a lot of time.
+Since ``ftw.testbrowser`` does nothing with JavaScript or CSS, cooking of resources is disabled
+by default for performance improvement.
+That means that ``<script>`` and ``<styles>`` tags are missing in the HTML.
+This can make the tests up to 4-5 times faster.
+
+Tests or projects which require to have the resource tags in the HTML can reenable them.
+
+**Enable by browser flag:**
+
+.. code::
+
+   @browsing
+   def test(self, browser):
+       browser.disable_resource_registries = False
+       browser.open()
+
+
+**Enable by environment variable:**
+
+.. code::
+
+   TESTBROWSER_DISABLE_RESOURCE_REGISTRIES = false

--- a/ftw/testbrowser/plone5.py
+++ b/ftw/testbrowser/plone5.py
@@ -1,0 +1,68 @@
+from contextlib import contextmanager
+from plone.app.layout.viewlets.interfaces import IHtmlHeadLinks
+from plone.app.layout.viewlets.interfaces import IScripts
+from Products.CMFPlone.resources.browser.scripts import ScriptsView
+from Products.CMFPlone.resources.browser.styles import StylesView
+from zope.browser.interfaces import IBrowserView
+from zope.component import getGlobalSiteManager
+from zope.interface import Interface
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+from zope.viewlet.interfaces import IViewlet
+import os
+
+
+ENV_NAME = 'TESTBROWSER_DISABLE_RESOURCE_REGISTRIES'
+
+
+class DisabledScriptsView(ScriptsView):
+
+    def update(self):
+        pass
+
+    def render(self):
+        return ''
+
+
+class DisabledStylesView(StylesView):
+
+    def update(self):
+        pass
+
+    def render(self):
+        return ''
+
+
+@contextmanager
+def disabled_resource_registries():
+    """In Plone 5 testing, the resources are cooked on each test, which is very time consuming.
+    The same test is 4-5x slower on Plone 5 than on Plone 4.
+    Since the testbrowser does not care about CSS and JavaScript, we can simply patch these
+    viewlets to be no longer executed, making the tests a lot faster.
+    """
+
+    if os.environ.get(ENV_NAME, '').lower() == 'false':
+        yield
+        return
+
+    sm = getGlobalSiteManager()
+
+    registrations = [
+        (DisabledScriptsView,
+         [Interface, IDefaultBrowserLayer, IBrowserView, IScripts],
+         IViewlet,
+         'plone.resourceregistries.scripts'),
+
+        (DisabledStylesView,
+         [Interface, IDefaultBrowserLayer, IBrowserView, IHtmlHeadLinks],
+         IViewlet,
+         'plone.resourceregistries.styles'),
+    ]
+
+    for registration in registrations:
+        sm.registerAdapter(*registration)
+
+    try:
+        yield
+    finally:
+        for registration in registrations:
+            sm.unregisterAdapter(*registration)

--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -9,6 +9,7 @@ import transaction
 
 
 IS_PLONE_4 = pkg_resources.get_distribution('Plone').version[:2] == '4.'
+IS_PLONE_5 = pkg_resources.get_distribution('Plone').version[:2] == '5.'
 
 
 class BrowserTestCase(TestCase):

--- a/ftw/testbrowser/tests/test_plone5.py
+++ b/ftw/testbrowser/tests/test_plone5.py
@@ -1,0 +1,44 @@
+from contextlib import contextmanager
+from ftw.testbrowser import browsing
+from ftw.testbrowser.tests import BrowserTestCase
+from ftw.testbrowser.tests import IS_PLONE_5
+from ftw.testbrowser.tests.alldrivers import all_drivers
+from unittest import skipUnless
+import os
+
+
+@all_drivers
+@skipUnless(IS_PLONE_5, 'folder_contents in plone 5 is js only.')
+class TestPlone5DisableResourceRegistries(BrowserTestCase):
+    """In Plone 5, bundling the resources takes too much time in testing.
+    ftw.testbrowser just disables the viewlets for JS and CSS for making it faster.
+    ftw.testbrowser does nothing with JS and CSS as it is not a full browser.
+    """
+
+    @browsing
+    def test_no_resource_registry_viewlets_by_default(self, browser):
+        browser.open()
+        self.assertFalse(browser.css('script'))
+
+    @browsing
+    def test_enable_resource_registries_by_environment_variable(self, browser):
+
+        with self.env('TESTBROWSER_DISABLE_RESOURCE_REGISTRIES', 'false'):
+            browser.open()
+            self.assertTrue(browser.css('script'))
+
+    @browsing
+    def test_enable_by_flag(self, browser):
+        browser.disable_resource_registries = False
+        browser.open()
+        self.assertTrue(browser.css('script'))
+
+    @contextmanager
+    def env(self, name, value):
+        self.assertNotIn(name, os.environ,
+                         'environment variable unexpectedly set')
+        os.environ[name] = value
+        try:
+            yield
+        finally:
+            os.environ.pop(name)


### PR DESCRIPTION
In Plone 5, the resource registries are cooked when the resource registry viewlets are rendered. Cooking the bundles takes a lot of time. Since ``ftw.testbrowser`` does nothing with JavaScript or CSS, cooking of resources is disabled by default for performance improvement. That means that ``<script>`` and ``<styles>`` tags are missing in the HTML. This can make the tests up to 4-5 times faster.

ℹ️ This goes into `1.x`. I'll forward-port it to `master`, but I need it in 1.x.