### PR TITLE
Use open from io for python2/3 compatibility.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Use open from io because of default mode changing. [busykoala]
+- Since the default mode changed in python3
+  [*[1](https://portingguide.readthedocs.io/en/latest/strings.html#file-i-o)] we should
+  use `from io import open` to make it compatible with both versions in `core.py`.
+  This is relevant for e.g. `browser.debug()` [busykoala]
 
 
 2.1.0 (2019-12-04)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use open from io because of default mode changing. [busykoala]
 
 
 2.1.0 (2019-12-04)

--- a/ftw/testbrowser/core.py
+++ b/ftw/testbrowser/core.py
@@ -29,6 +29,7 @@ from ftw.testbrowser.queryinfo import QueryInfo
 from ftw.testbrowser.utils import basic_auth_encode
 from ftw.testbrowser.utils import normalize_spaces
 from functools import reduce
+from io import open
 from lxml.cssselect import CSSSelector
 from OFS.interfaces import IItem
 from operator import attrgetter


### PR DESCRIPTION
Close https://github.com/4teamwork/ftw.testbrowser/issues/101

Since the default mode changed in python3 [*[1](https://portingguide.readthedocs.io/en/latest/strings.html#file-i-o)] we should use `from io import open` to make it compatible with both versions in `core.py`. This is relevant for e.g. `browser.debug()`