### PR TITLE
editbar.menu can now find workflow contentmenu in Plone5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- editbar.menu can now find workflow contentmenu in Plone5. [djowett-ftw]
 
 
 2.1.1 (2020-02-19)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- editbar.menu can now find workflow contentmenu in Plone5. [djowett-ftw]
+- editbar.menu and editbar.menus can now find workflow contentmenu in Plone5. [djowett-ftw]
 
 
 2.1.1 (2020-02-19)

--- a/ftw/testbrowser/pages/editbar.py
+++ b/ftw/testbrowser/pages/editbar.py
@@ -102,7 +102,7 @@ def menu(label, browser=default_browser, query_info=None):
 
     else:
         for menu in container(browser=browser).css('nav li[id^="plone-contentmenu-"]'):
-            for span in menu.css('a > span.plone-toolbar-title'):
+            for span in menu.css('a span.plone-toolbar-title'):
                 if normalize_spaces(span.text_content()).rstrip(u'\u2026') == label:
                     return menu
 

--- a/ftw/testbrowser/pages/editbar.py
+++ b/ftw/testbrowser/pages/editbar.py
@@ -73,7 +73,7 @@ def menus(browser=default_browser):
             # Plone 4
             '#contentActionMenus .actionMenuHeader > a > span:first-child, '
             # Plone 5
-            'nav li[id^="plone-contentmenu-"] > a > span.plone-toolbar-title'
+            'nav li[id^="plone-contentmenu-"] > a span.plone-toolbar-title'
         ).text
     ]
 

--- a/ftw/testbrowser/testing.py
+++ b/ftw/testbrowser/testing.py
@@ -48,6 +48,7 @@ class BrowserLayer(PloneSandboxLayer):
         z2.installProduct(app, 'Products.DateRecurringIndex')
 
     def setUpPloneSite(self, portal):
+        applyProfile(portal, 'Products.CMFPlone:testfixture')
         applyProfile(portal, 'ftw.testbrowser.tests:dxtype')
         applyProfile(portal, 'plone.app.contenttypes:default')
         applyProfile(portal, 'collective.z3cform.datagridfield:default')

--- a/ftw/testbrowser/tests/test_pages_editbar.py
+++ b/ftw/testbrowser/tests/test_pages_editbar.py
@@ -8,6 +8,7 @@ from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import nondefault_browsing
 
 import re
+import six
 
 
 @all_drivers
@@ -133,7 +134,8 @@ class TestEditBar(BrowserTestCase):
             " browser=<ftw.browser.core.Browser instance>)"
             " did not match any nodes."
             "\nOptions in menu 'Add new': ['Collection', 'DXType', 'Event',"
-            " 'File', 'Folder', 'Image', 'Link', 'News Item', 'Page', u'Restrictions\u2026']",
+            " 'File', 'Folder', 'Image', 'Link', 'News Item', 'Page', " +
+            ("u" if six.PY2 else "") + "'Restrictions\u2026']",
             str(cm.exception))
 
     @nondefault_browsing

--- a/ftw/testbrowser/tests/test_pages_editbar.py
+++ b/ftw/testbrowser/tests/test_pages_editbar.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.tests import BrowserTestCase
@@ -10,6 +12,10 @@ import re
 
 @all_drivers
 class TestEditBar(BrowserTestCase):
+
+    def setUp(self):
+        super(TestEditBar, self).setUp()
+        self.folder = create(Builder('folder').titled(u'The Folder'))
 
     @nondefault_browsing
     def test_visible(self, browser):
@@ -57,18 +63,18 @@ class TestEditBar(BrowserTestCase):
     @nondefault_browsing
     def test_menus(self, browser):
         self.grant('Manager')
-        browser.login().open()
+        browser.login().open(self.folder)
         if IS_PLONE_4:
             self.assertEqual([u'Add new', 'Display'],
                              editbar.menus(browser=browser))
         else:
-            self.assertEqual([u'Add new', 'Display', 'Manage portlets'],
+            self.assertEqual([u'Add new', 'Actions', 'Display', 'Manage portlets'],
                              editbar.menus(browser=browser))
 
     @nondefault_browsing
     def test_menu(self, browser):
         self.grant('Manager')
-        browser.login().open()
+        browser.login().open(self.folder)
         if IS_PLONE_4:
             self.assertIn('actionMenu', editbar.menu('Display', browser=browser).classes)
             self.assertIn('actionMenu', editbar.menu('Add new', browser=browser).classes)
@@ -81,7 +87,7 @@ class TestEditBar(BrowserTestCase):
     @nondefault_browsing
     def test_menu_not_found(self, browser):
         self.grant('Manager')
-        browser.login().open()
+        browser.login().open(self.folder)
         with self.assertRaises(NoElementFound) as cm:
             editbar.menu('Shapes', browser=browser)
 
@@ -95,19 +101,19 @@ class TestEditBar(BrowserTestCase):
             self.assertEqual(
                 "Empty result set: editbar.menu('Shapes',"
                 " browser=<ftw.browser.core.Browser instance>) did not match any nodes."
-                "\nVisible menus: ['Add new', 'Display', 'Manage portlets'].",
+                "\nVisible menus: ['Add new', 'Actions', 'Display', 'Manage portlets'].",
                 str(cm.exception))
 
     @nondefault_browsing
     def test_menu_options(self, browser):
         self.grant('Manager')
-        browser.login().open()
+        browser.login().open(self.folder)
         self.assertIn('Summary view', editbar.menu_options('Display', browser=browser))
 
     @nondefault_browsing
     def test_menu_option(self, browser):
         self.grant('Manager')
-        browser.login().open()
+        browser.login().open(self.folder)
         link = editbar.menu_option('Display', 'Summary view', browser=browser)
         self.assertEqual('plone-contentmenu-display-summary_view',
                          link.attrib.get('id'))
@@ -116,7 +122,7 @@ class TestEditBar(BrowserTestCase):
     @nondefault_browsing
     def test_menu_option_not_found(self, browser):
         self.grant('Manager')
-        browser.login().open()
+        browser.login().open(self.folder)
         with self.assertRaises(NoElementFound) as cm:
             editbar.menu_option('Add new', 'Dog', browser=browser)
 
@@ -125,13 +131,13 @@ class TestEditBar(BrowserTestCase):
             " browser=<ftw.browser.core.Browser instance>)"
             " did not match any nodes."
             "\nOptions in menu 'Add new': ['Collection', 'DXType', 'Event',"
-            " 'File', 'Folder', 'Image', 'Link', 'News Item', 'Page']",
+            " 'File', 'Folder', 'Image', 'Link', 'News Item', 'Page', u'Restrictions\u2026']",
             str(cm.exception))
 
     @nondefault_browsing
     def test_menu_option_menu_not_found(self, browser):
         self.grant('Manager')
-        browser.login().open()
+        browser.login().open(self.folder)
         with self.assertRaises(NoElementFound) as cm:
             editbar.menu_option('Shapes', 'Square', browser=browser)
 
@@ -147,7 +153,7 @@ class TestEditBar(BrowserTestCase):
                 "Empty result set: editbar.menu_option('Shapes', 'Square',"
                 " browser=<ftw.browser.core.Browser instance>)"
                 " did not match any nodes."
-                "\nVisible menus: ['Add new', 'Display', 'Manage portlets'].",
+                "\nVisible menus: ['Add new', 'Actions', 'Display', 'Manage portlets'].",
                 str(cm.exception))
 
     @nondefault_browsing

--- a/ftw/testbrowser/tests/test_pages_editbar.py
+++ b/ftw/testbrowser/tests/test_pages_editbar.py
@@ -65,7 +65,7 @@ class TestEditBar(BrowserTestCase):
         self.grant('Manager')
         browser.login().open(self.folder)
         if IS_PLONE_4:
-            self.assertEqual([u'Add new', 'Display'],
+            self.assertEqual([u'State:', 'Add new', 'Display', 'Actions'],
                              editbar.menus(browser=browser))
         else:
             self.assertEqual([u'Add new', 'State:', 'Actions', 'Display', 'Manage portlets'],
@@ -97,7 +97,7 @@ class TestEditBar(BrowserTestCase):
             self.assertEqual(
                 "Empty result set: editbar.menu('Shapes',"
                 " browser=<ftw.browser.core.Browser instance>) did not match any nodes."
-                "\nVisible menus: ['Add new', 'Display'].",
+                "\nVisible menus: ['State:', 'Add new', 'Display', 'Actions'].",
                 str(cm.exception))
         else:
             self.assertEqual(
@@ -148,7 +148,7 @@ class TestEditBar(BrowserTestCase):
                 "Empty result set: editbar.menu_option('Shapes', 'Square',"
                 " browser=<ftw.browser.core.Browser instance>)"
                 " did not match any nodes."
-                "\nVisible menus: ['Add new', 'Display'].",
+                "\nVisible menus: ['State:', 'Add new', 'Display', 'Actions'].",
                 str(cm.exception))
         else:
             self.assertEqual(

--- a/ftw/testbrowser/tests/test_pages_editbar.py
+++ b/ftw/testbrowser/tests/test_pages_editbar.py
@@ -68,7 +68,7 @@ class TestEditBar(BrowserTestCase):
             self.assertEqual([u'Add new', 'Display'],
                              editbar.menus(browser=browser))
         else:
-            self.assertEqual([u'Add new', 'Actions', 'Display', 'Manage portlets'],
+            self.assertEqual([u'Add new', 'State:', 'Actions', 'Display', 'Manage portlets'],
                              editbar.menus(browser=browser))
 
     @nondefault_browsing
@@ -83,6 +83,8 @@ class TestEditBar(BrowserTestCase):
                              editbar.menu('Display', browser=browser).attrib['id'])
             self.assertEqual('plone-contentmenu-factories',
                              editbar.menu('Add new', browser=browser).attrib['id'])
+            self.assertEqual('plone-contentmenu-workflow',
+                             editbar.menu('State:', browser=browser).attrib['id'])
 
     @nondefault_browsing
     def test_menu_not_found(self, browser):
@@ -101,7 +103,7 @@ class TestEditBar(BrowserTestCase):
             self.assertEqual(
                 "Empty result set: editbar.menu('Shapes',"
                 " browser=<ftw.browser.core.Browser instance>) did not match any nodes."
-                "\nVisible menus: ['Add new', 'Actions', 'Display', 'Manage portlets'].",
+                "\nVisible menus: ['Add new', 'State:', 'Actions', 'Display', 'Manage portlets'].",
                 str(cm.exception))
 
     @nondefault_browsing
@@ -153,7 +155,7 @@ class TestEditBar(BrowserTestCase):
                 "Empty result set: editbar.menu_option('Shapes', 'Square',"
                 " browser=<ftw.browser.core.Browser instance>)"
                 " did not match any nodes."
-                "\nVisible menus: ['Add new', 'Actions', 'Display', 'Manage portlets'].",
+                "\nVisible menus: ['Add new', 'State:', 'Actions', 'Display', 'Manage portlets'].",
                 str(cm.exception))
 
     @nondefault_browsing


### PR DESCRIPTION
I also extended the tests to cover this use case, but they were just checking menus on Plone site which doesn't have workflow. So switched to a folder - which needed to be assigned workflow so the workflow menu actually shows up

