### PR TITLE
Freeze datetime for autogenerated date range.

### DIFF
--- a/ftw/testbrowser/tests/test_widgets_datetime.py
+++ b/ftw/testbrowser/tests/test_widgets_datetime.py
@@ -3,6 +3,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests.alldrivers import all_drivers
+from ftw.testing import freeze
 from plone.app.testing import SITE_OWNER_NAME
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
@@ -22,20 +23,22 @@ class TestDatetimeWidget(BrowserTestCase):
 
     @browsing
     def test_z3cform_formfill(self, browser):
-        browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
-        browser.fill({'Delivery date': datetime(2010, 12, 22, 10, 30, 0)})
-        browser.find('Submit').click()
+        with freeze(datetime(2017, 10, 16, 0, 0)):
+            browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
+            browser.fill({'Delivery date': datetime(2010, 12, 22, 10, 30, 0)})
+            browser.find('Submit').click()
         self.assertEqual({u'delivery_date': u'2010-12-22T10:30:00'},
                          browser.json)
 
     @browsing
     def test_formfill(self, browser):
-        browser.login(SITE_OWNER_NAME).open()
-        factoriesmenu.add('Event')
-        browser.fill({'Title': 'Event',
-                      'Event Starts': datetime(2010, 5, 3, 23, 30, 0),
-                      'Event Ends': datetime(2010, 12, 23, 10, 5, 0)})
-        browser.find('Save').click()
+        with freeze(datetime(2017, 10, 16, 0, 0)):
+            browser.login(SITE_OWNER_NAME).open()
+            factoriesmenu.add('Event')
+            browser.fill({'Title': 'Event',
+                          'Event Starts': datetime(2010, 5, 3, 23, 30, 0),
+                          'Event Ends': datetime(2010, 12, 23, 10, 5, 0)})
+            browser.find('Save').click()
 
         self.assertEqual(['2010-05-03T23:30:00+02:00'],
                          browser.css('li.dtstart').text)


### PR DESCRIPTION
The date range that is tested against seems to be genreated based on the current date. We have now entered the year 2021 and the option 2010 is no longer available.