### PR TITLE
Fix cookie tests for Plone >= 5.2

### DIFF
--- a/ftw/testbrowser/tests/__init__.py
+++ b/ftw/testbrowser/tests/__init__.py
@@ -3,6 +3,7 @@ from ftw.testbrowser import LIB_TRAVERSAL
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from Products.CMFPlone.utils import getFSVersionTuple
 from unittest import TestCase
 
 import pkg_resources
@@ -11,6 +12,7 @@ import transaction
 
 IS_PLONE_4 = pkg_resources.get_distribution('Plone').version[:2] == '4.'
 IS_PLONE_5 = pkg_resources.get_distribution('Plone').version[:2] == '5.'
+PLONE_VERSION = getFSVersionTuple()
 
 
 class BrowserTestCase(TestCase):

--- a/ftw/testbrowser/tests/test_browser.py
+++ b/ftw/testbrowser/tests/test_browser.py
@@ -9,6 +9,7 @@ from ftw.testbrowser.exceptions import BrowserNotSetUpException
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.tests import BrowserTestCase
 from ftw.testbrowser.tests import IS_PLONE_4
+from ftw.testbrowser.tests import PLONE_VERSION
 from ftw.testbrowser.tests.alldrivers import all_drivers
 from ftw.testbrowser.tests.helpers import capture_streams
 from ftw.testbrowser.tests.helpers import register_view
@@ -24,6 +25,8 @@ from zope.publisher.browser import BrowserView
 import six
 
 
+HTTP_ONLY = 'HTTPOnly' if PLONE_VERSION < (5, 2, 0) else 'HttpOnly'
+
 AC_COOKIE_INFO = {'comment': None,
                   # 'domain': ... may be 'localhost.local' or '0.0.0.0'
                   'name': '__ac',
@@ -31,7 +34,7 @@ AC_COOKIE_INFO = {'comment': None,
                   'expires': None,
                   # 'value': ...,  The value changes.
                   'domain_specified': False,
-                  '_rest': {'HTTPOnly': None},
+                  '_rest': {HTTP_ONLY: None},
                   'version': 0,
                   'port_specified': False,
                   'rfc2109': False,


### PR DESCRIPTION
The spelling of the 'HTTPOnly' cookie flag (Plone 4) was corrected to 'HttpOnly' in more recent versions of ZPublisher.

For [CA-1243](https://4teamwork.atlassian.net/browse/CA-1243)

Fixes test failures like [these](https://ci.4teamwork.ch/builds/540935/tasks/1053474).