### PR TITLE
Use Python 3.8 instead of 3.7 for Plone 5.2 tests.

### DIFF
--- a/test-plone-5.2.x-py38.cfg
+++ b/test-plone-5.2.x-py38.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py37.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py38.cfg
     sources.cfg
 
 package-name = ftw.testbrowser


### PR DESCRIPTION
Use Python 3.8 instead of 3.7 for Plone 5.2 tests.

For [CA-2571](https://4teamwork.atlassian.net/browse/CA-2571)